### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -9,6 +9,25 @@
   color: var(--text-primary);
 }
 
+.theme-toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 40;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.72rem;
+  border-radius: 999px;
+  box-shadow: 0 10px 28px var(--shadow-strong);
+  backdrop-filter: blur(10px);
+}
+
+.theme-toggle-icon {
+  width: 1.15rem;
+  text-align: center;
+}
+
 .bg-art {
   position: fixed;
   inset: 0;
@@ -51,6 +70,11 @@
   animation-delay: 1.5s;
 }
 
+[data-theme='dark'] .blob {
+  opacity: 0.42;
+  filter: blur(14px);
+}
+
 @keyframes drift {
   0%,
   100% {
@@ -68,7 +92,7 @@
   padding: 1rem;
   width: 100%;
   min-width: 0;
-  box-shadow: 0 20px 35px rgba(7, 16, 25, 0.08);
+  box-shadow: 0 20px 35px var(--shadow-soft);
   backdrop-filter: blur(8px);
 }
 
@@ -224,8 +248,8 @@ input,
 select,
 textarea {
   width: 100%;
-  border: 1px solid rgba(20, 67, 95, 0.26);
-  background: #ffffff;
+  border: 1px solid var(--field-border);
+  background: var(--field-bg);
   border-radius: 0.7rem;
   padding: 0.65rem 0.72rem;
   color: var(--text-primary);
@@ -271,7 +295,7 @@ textarea:focus {
   right: 0.4rem;
   transform: translateY(-50%);
   border: 1px solid var(--surface-border);
-  background: #f7fafc;
+  background: var(--surface-soft);
   color: var(--text-secondary);
   padding: 0.28rem 0.55rem;
   border-radius: 0.5rem;
@@ -313,7 +337,7 @@ button:disabled {
 }
 
 .ghost {
-  background: rgba(250, 252, 255, 0.72);
+  background: var(--surface-soft);
   border: 1px solid var(--surface-border);
   color: var(--text-primary);
 }
@@ -414,7 +438,7 @@ button:disabled {
 .easy-alert-card {
   border: 1px solid var(--surface-border);
   border-radius: 0.9rem;
-  background: rgba(248, 252, 255, 0.82);
+  background: var(--surface-soft);
   text-align: left;
   padding: 0.72rem;
   color: var(--text-primary);
@@ -424,13 +448,13 @@ button:disabled {
 
 .easy-alert-card:hover {
   border-color: rgba(24, 79, 115, 0.42);
-  background: rgba(241, 249, 255, 0.92);
+  background: var(--surface-soft-hover);
   box-shadow: 0 10px 18px rgba(12, 31, 46, 0.1);
 }
 
 .easy-alert-card.is-hovered {
   border-color: rgba(24, 79, 115, 0.42);
-  background: rgba(241, 249, 255, 0.92);
+  background: var(--surface-soft-hover);
   box-shadow: 0 10px 18px rgba(12, 31, 46, 0.1);
 }
 
@@ -514,7 +538,7 @@ button:disabled {
   border: 1px solid var(--surface-border);
   border-radius: 0.85rem;
   padding: 0.75rem;
-  background: rgba(255, 255, 255, 0.66);
+  background: var(--surface-soft);
 }
 
 .recovery-inline-note {
@@ -633,7 +657,7 @@ button:disabled {
   padding: 0.38rem 0.62rem;
   border-radius: 999px;
   border: 1px solid var(--surface-border);
-  background: rgba(255, 255, 255, 0.76);
+  background: var(--surface-soft);
   color: var(--text-secondary);
   text-decoration: none;
   font-size: 0.82rem;
@@ -642,7 +666,7 @@ button:disabled {
 
 .shell-location-chip:hover {
   color: var(--text-primary);
-  border-color: rgba(29, 106, 144, 0.28);
+  border-color: var(--surface-border-strong);
 }
 
 .create-plus-svg {
@@ -671,7 +695,7 @@ button:disabled {
   font-weight: 700;
   color: var(--accent-700);
   border: 1px solid rgba(29, 106, 144, 0.22);
-  background: rgba(240, 249, 255, 0.8);
+  background: var(--avatar-bg);
 }
 
 .shell-user-id {
@@ -682,8 +706,8 @@ button:disabled {
 .shell-user-popover {
   border-radius: 0.75rem;
   border: 1px solid var(--surface-border);
-  background: #ffffff;
-  box-shadow: 0 18px 28px rgba(7, 16, 25, 0.16);
+  background: var(--surface-popover);
+  box-shadow: 0 18px 28px var(--shadow-strong);
   padding: 0.3rem;
 }
 
@@ -738,7 +762,7 @@ button:disabled {
 }
 
 .shell-nav-link:hover {
-  background: rgba(245, 250, 254, 0.92);
+  background: var(--hover-surface);
   border-color: var(--surface-border);
   color: var(--text-primary);
 }
@@ -757,7 +781,7 @@ button:disabled {
 .shell-drawer-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(6, 14, 23, 0.4);
+  background: var(--backdrop-strong);
   display: flex;
   justify-content: flex-start;
   z-index: 30;
@@ -772,9 +796,9 @@ button:disabled {
 .shell-drawer-dialog {
   height: 100%;
   border-right: 1px solid var(--surface-border);
-  background: #ffffff;
+  background: var(--surface-popover);
   padding: 0.85rem;
-  box-shadow: 0 20px 35px rgba(7, 16, 25, 0.2);
+  box-shadow: 0 20px 35px var(--shadow-strong);
 }
 
 .shell-drawer-top {
@@ -822,13 +846,13 @@ button:disabled {
 }
 
 .app-nav-link:hover {
-  background: rgba(245, 250, 254, 0.92);
+  background: var(--hover-surface);
   border-color: var(--surface-border);
   color: var(--text-primary);
 }
 
 .app-nav-link[data-hovered] {
-  background: rgba(245, 250, 254, 0.92);
+  background: var(--hover-surface);
   border-color: var(--surface-border);
   color: var(--text-primary);
 }
@@ -893,7 +917,7 @@ button:disabled {
   display: grid;
   place-items: center;
   padding: 1.5rem;
-  background: rgba(235, 244, 250, 0.72);
+  background: var(--backdrop-soft);
   backdrop-filter: blur(8px);
 }
 
@@ -906,7 +930,7 @@ button:disabled {
   padding: 1.2rem 1.35rem;
   border-radius: 1rem;
   border: 1px solid rgba(29, 106, 144, 0.16);
-  background: rgba(255, 255, 255, 0.94);
+  background: var(--surface-popover);
   box-shadow: 0 24px 45px rgba(11, 31, 44, 0.14);
   text-align: center;
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { BrowserRouter, Navigate, Outlet, Route, Routes, useLocation } from 'react-router-dom'
 import './App.css'
 import { AuthenticatedLayout } from './components/layout/AuthenticatedLayout'
@@ -15,6 +16,23 @@ import { OverviewPage } from './pages/OverviewPage'
 import { RulesPage } from './pages/RulesPage'
 import { AppStateProvider } from './state/AppStateContext'
 import { useAppState } from './state/useAppState'
+
+const THEME_STORAGE_KEY = 'weather-alert-theme'
+
+type Theme = 'light' | 'dark'
+type ThemePreference = Theme | 'system'
+
+function resolveTheme(themePreference: ThemePreference): Theme {
+  if (themePreference !== 'system') {
+    return themePreference
+  }
+
+  if (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    return 'dark'
+  }
+
+  return 'light'
+}
 
 function RootRedirect() {
   const { token } = useAppState()
@@ -77,8 +95,64 @@ function AppRoutes() {
 }
 
 export default function App() {
+  const [themePreference, setThemePreference] = useState<ThemePreference>(() => {
+    if (typeof window === 'undefined') {
+      return 'system'
+    }
+
+    const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY)
+    if (storedTheme === 'light' || storedTheme === 'dark') {
+      return storedTheme
+    }
+
+    return 'system'
+  })
+  const [theme, setTheme] = useState<Theme>(() => resolveTheme(themePreference))
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme
+    document.documentElement.style.colorScheme = theme
+  }, [theme])
+
+  useEffect(() => {
+    if (themePreference === 'system') {
+      window.localStorage.removeItem(THEME_STORAGE_KEY)
+    } else {
+      window.localStorage.setItem(THEME_STORAGE_KEY, themePreference)
+    }
+  }, [themePreference])
+
+  useEffect(() => {
+    setTheme(resolveTheme(themePreference))
+
+    if (themePreference !== 'system') {
+      return undefined
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+
+    function handleChange(event: MediaQueryListEvent) {
+      setTheme(event.matches ? 'dark' : 'light')
+    }
+
+    mediaQuery.addEventListener('change', handleChange)
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [themePreference])
+
   return (
     <AppStateProvider>
+      <button
+        type="button"
+        className="theme-toggle ghost"
+        aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+        onClick={() => setThemePreference((currentTheme) => (resolveTheme(currentTheme) === 'dark' ? 'light' : 'dark'))}
+      >
+        <span className="theme-toggle-icon" aria-hidden>
+          {theme === 'dark' ? '☾' : '☀'}
+        </span>
+        <span>{theme === 'dark' ? 'Dark' : 'Light'} mode</span>
+      </button>
+
       <BrowserRouter>
         <AppRoutes />
       </BrowserRouter>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -6,8 +6,23 @@
   --font-mono: 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
 
   --bg: #eef5ff;
+  --bg-gradient-top: rgba(255, 202, 120, 0.22);
+  --bg-gradient-right: rgba(114, 177, 230, 0.2);
+  --bg-gradient-bottom: #e8f3ff;
   --surface: rgba(255, 255, 255, 0.9);
+  --surface-soft: rgba(248, 252, 255, 0.82);
+  --surface-soft-hover: rgba(241, 249, 255, 0.92);
+  --surface-popover: #ffffff;
+  --surface-border-strong: rgba(29, 106, 144, 0.28);
   --surface-border: rgba(29, 79, 112, 0.2);
+  --field-bg: #ffffff;
+  --field-border: rgba(20, 67, 95, 0.26);
+  --hover-surface: rgba(245, 250, 254, 0.92);
+  --avatar-bg: rgba(240, 249, 255, 0.8);
+  --backdrop-soft: rgba(235, 244, 250, 0.72);
+  --backdrop-strong: rgba(6, 14, 23, 0.4);
+  --shadow-soft: rgba(7, 16, 25, 0.08);
+  --shadow-strong: rgba(7, 16, 25, 0.16);
 
   --text-primary: #173043;
   --text-secondary: #35566d;
@@ -25,6 +40,32 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+[data-theme='dark'] {
+  --bg: #09131c;
+  --bg-gradient-top: rgba(245, 163, 86, 0.16);
+  --bg-gradient-right: rgba(54, 111, 156, 0.2);
+  --bg-gradient-bottom: #0e1b28;
+  --surface: rgba(10, 21, 31, 0.82);
+  --surface-soft: rgba(13, 25, 37, 0.78);
+  --surface-soft-hover: rgba(18, 35, 49, 0.88);
+  --surface-popover: #12202d;
+  --surface-border: rgba(122, 170, 205, 0.24);
+  --surface-border-strong: rgba(116, 180, 221, 0.38);
+  --field-bg: rgba(11, 23, 34, 0.92);
+  --field-border: rgba(109, 157, 190, 0.26);
+  --hover-surface: rgba(20, 39, 54, 0.92);
+  --avatar-bg: rgba(17, 36, 51, 0.92);
+  --backdrop-soft: rgba(8, 16, 24, 0.76);
+  --backdrop-strong: rgba(3, 8, 12, 0.7);
+  --shadow-soft: rgba(0, 0, 0, 0.28);
+  --shadow-strong: rgba(0, 0, 0, 0.45);
+  --text-primary: #e8f2fb;
+  --text-secondary: #b4cbda;
+  --text-muted: #7f99aa;
+  --accent-500: #6bb2da;
+  --accent-700: #9ed6fb;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -34,9 +75,10 @@ body {
   margin: 0;
   min-width: 320px;
   background:
-    radial-gradient(1200px 500px at 10% -10%, rgba(255, 202, 120, 0.22), transparent 55%),
-    radial-gradient(1000px 420px at 100% 0%, rgba(114, 177, 230, 0.2), transparent 60%),
-    linear-gradient(180deg, #eef5ff 0%, #e8f3ff 100%);
+    radial-gradient(1200px 500px at 10% -10%, var(--bg-gradient-top), transparent 55%),
+    radial-gradient(1000px 420px at 100% 0%, var(--bg-gradient-right), transparent 60%),
+    linear-gradient(180deg, var(--bg) 0%, var(--bg-gradient-bottom) 100%);
+  transition: background 180ms ease, color 180ms ease;
 }
 
 body {


### PR DESCRIPTION
## Summary
- add a global light/dark mode toggle for the React UI
- persist the user theme choice and default to system preference
- update shared color tokens and key surfaces so auth and app views both render correctly in dark mode

## Testing
- npm run build
