### PR TITLE
fix: widen weather location columns

### DIFF
--- a/src/main/java/com/weather/alert/infrastructure/adapter/persistence/AlertEntity.java
+++ b/src/main/java/com/weather/alert/infrastructure/adapter/persistence/AlertEntity.java
@@ -46,7 +46,7 @@ public class AlertEntity {
     @Column(name = "description", length = 5000)
     private String description;
     
-    @Column(name = "location")
+    @Column(name = "location", columnDefinition = "TEXT")
     private String location;
 
     @Column(name = "condition_source", length = 64)

--- a/src/main/java/com/weather/alert/infrastructure/adapter/persistence/WeatherDataEntity.java
+++ b/src/main/java/com/weather/alert/infrastructure/adapter/persistence/WeatherDataEntity.java
@@ -22,7 +22,7 @@ public class WeatherDataEntity {
     @Id
     private String id;
 
-    @Column(name = "location", length = 255)
+    @Column(name = "location", columnDefinition = "TEXT")
     private String location;
 
     @Column(name = "latitude")

--- a/src/main/resources/db/migration/V15__expand_location_columns.sql
+++ b/src/main/resources/db/migration/V15__expand_location_columns.sql
@@ -1,0 +1,5 @@
+ALTER TABLE weather_data
+    ALTER COLUMN location TYPE TEXT;
+
+ALTER TABLE alerts
+    ALTER COLUMN location TYPE TEXT;

--- a/src/test/java/com/weather/alert/infrastructure/adapter/persistence/WeatherDataSearchRepositoryAdapterTest.java
+++ b/src/test/java/com/weather/alert/infrastructure/adapter/persistence/WeatherDataSearchRepositoryAdapterTest.java
@@ -57,6 +57,24 @@ class WeatherDataSearchRepositoryAdapterTest {
                 .containsExactly("new-1");
     }
 
+    @Test
+    void shouldPersistLocationLongerThanLegacyVarcharLimit() {
+        String longLocation = "Orlando; " + "Seminole, Orange, Osceola, Lake, Volusia, Brevard, Polk, "
+                .repeat(8);
+
+        adapter.indexWeatherData(sample("long-location-1", longLocation, "Flood Warning", "Moderate",
+                Instant.parse("2026-03-07T12:00:00Z")));
+
+        PagedResult<WeatherData> result = adapter.getActiveWeatherData(0, 10);
+
+        assertThat(result.getItems()).extracting(WeatherData::getId).contains("long-location-1");
+        assertThat(result.getItems().stream()
+                .filter(item -> "long-location-1".equals(item.getId()))
+                .findFirst()
+                .map(WeatherData::getLocation))
+                .contains(longLocation);
+    }
+
     private WeatherData sample(String id, String location, String eventType, String severity, Instant timestamp) {
         return WeatherData.builder()
                 .id(id)


### PR DESCRIPTION
## Summary
- widen long NOAA location fields from `VARCHAR(255)` to `TEXT`
- add a Flyway migration for `weather_data.location` and `alerts.location`
- add a regression test covering a location longer than the legacy limit

## Validation
- `mvn test -Dtest=WeatherDataSearchRepositoryAdapterTest,ApiIntegrationContractTest`
