### PR TITLE
feat: disable excess alerts on plan downgrade

### DIFF
--- a/src/main/java/com/weather/alert/application/usecase/HandleStripeWebhookUseCase.java
+++ b/src/main/java/com/weather/alert/application/usecase/HandleStripeWebhookUseCase.java
@@ -1,14 +1,19 @@
 package com.weather.alert.application.usecase;
 
+import com.weather.alert.application.service.BillingPlanService;
+import com.weather.alert.domain.model.AlertCriteria;
+import com.weather.alert.domain.model.BillingEntitlements;
 import com.weather.alert.domain.model.BillingWebhookEvent;
 import com.weather.alert.domain.model.BillingWebhookEventType;
 import com.weather.alert.domain.model.User;
+import com.weather.alert.domain.port.AlertCriteriaRepositoryPort;
 import com.weather.alert.domain.port.BillingProviderPort;
 import com.weather.alert.domain.port.UserRepositoryPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -17,6 +22,8 @@ public class HandleStripeWebhookUseCase {
 
     private final BillingProviderPort billingProviderPort;
     private final UserRepositoryPort userRepositoryPort;
+    private final AlertCriteriaRepositoryPort alertCriteriaRepositoryPort;
+    private final BillingPlanService billingPlanService;
 
     @Transactional
     public void handle(String payload, String signatureHeader) {
@@ -25,7 +32,7 @@ public class HandleStripeWebhookUseCase {
             return;
         }
 
-        resolveUser(event).ifPresent(user -> userRepositoryPort.save(applyEvent(user, event)));
+        resolveUser(event).ifPresent(user -> persistUpdatedBillingState(user, event));
     }
 
     private Optional<User> resolveUser(BillingWebhookEvent event) {
@@ -45,6 +52,42 @@ public class HandleStripeWebhookUseCase {
             return userRepositoryPort.findByStripeCustomerId(event.getStripeCustomerId());
         }
         return Optional.empty();
+    }
+
+    private void persistUpdatedBillingState(User user, BillingWebhookEvent event) {
+        BillingEntitlements previousEntitlements = billingPlanService.resolveEntitlements(user);
+        User updatedUser = applyEvent(user, event);
+        BillingEntitlements updatedEntitlements = billingPlanService.resolveEntitlements(updatedUser);
+
+        userRepositoryPort.save(updatedUser);
+        disableExcessActiveCriteria(updatedUser.getId(), previousEntitlements, updatedEntitlements);
+    }
+
+    private void disableExcessActiveCriteria(
+            String userId,
+            BillingEntitlements previousEntitlements,
+            BillingEntitlements updatedEntitlements) {
+        if (userId == null || userId.isBlank() || previousEntitlements == null || updatedEntitlements == null) {
+            return;
+        }
+        if (updatedEntitlements.getMaxActiveAlerts() >= previousEntitlements.getMaxActiveAlerts()) {
+            return;
+        }
+
+        List<AlertCriteria> enabledCriteria = alertCriteriaRepositoryPort.findByUserId(userId).stream()
+                .filter(criteria -> Boolean.TRUE.equals(criteria.getEnabled()))
+                .toList();
+
+        if (enabledCriteria.size() <= updatedEntitlements.getMaxActiveAlerts()) {
+            return;
+        }
+
+        enabledCriteria.stream()
+                .skip(updatedEntitlements.getMaxActiveAlerts())
+                .forEach(criteria -> {
+                    criteria.setEnabled(false);
+                    alertCriteriaRepositoryPort.save(criteria);
+                });
     }
 
     private User applyEvent(User user, BillingWebhookEvent event) {

--- a/src/main/java/com/weather/alert/domain/model/AlertCriteria.java
+++ b/src/main/java/com/weather/alert/domain/model/AlertCriteria.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
+
 /**
  * Domain model representing user alert criteria
  */
@@ -147,6 +149,9 @@ public class AlertCriteria {
 
     @Schema(example = "true")
     private Boolean enabled;
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY)
+    private Instant createdAt;
     
     public boolean matches(WeatherData weatherData) {
         return AlertCriteriaRuleEvaluator.defaultInstance().matches(this, weatherData);

--- a/src/main/java/com/weather/alert/infrastructure/adapter/persistence/AlertCriteriaEntity.java
+++ b/src/main/java/com/weather/alert/infrastructure/adapter/persistence/AlertCriteriaEntity.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
+
 @Entity
 @Table(name = "alert_criteria")
 @Data
@@ -127,4 +129,7 @@ public class AlertCriteriaEntity {
     
     @Column(name = "enabled")
     private Boolean enabled;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
 }

--- a/src/main/java/com/weather/alert/infrastructure/adapter/persistence/AlertCriteriaRepositoryAdapter.java
+++ b/src/main/java/com/weather/alert/infrastructure/adapter/persistence/AlertCriteriaRepositoryAdapter.java
@@ -5,6 +5,7 @@ import com.weather.alert.domain.port.AlertCriteriaRepositoryPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -29,7 +30,7 @@ public class AlertCriteriaRepositoryAdapter implements AlertCriteriaRepositoryPo
     
     @Override
     public List<AlertCriteria> findByUserId(String userId) {
-        return jpaRepository.findByUserId(userId).stream()
+        return jpaRepository.findByUserIdOrderByCreatedAtAscIdAsc(userId).stream()
                 .map(this::toDomain)
                 .collect(Collectors.toList());
     }
@@ -83,6 +84,7 @@ public class AlertCriteriaRepositoryAdapter implements AlertCriteriaRepositoryPo
                 .oncePerEvent(criteria.getOncePerEvent())
                 .rearmWindowMinutes(criteria.getRearmWindowMinutes())
                 .enabled(criteria.getEnabled())
+                .createdAt(criteria.getCreatedAt() == null ? Instant.now() : criteria.getCreatedAt())
                 .build();
     }
     
@@ -123,6 +125,7 @@ public class AlertCriteriaRepositoryAdapter implements AlertCriteriaRepositoryPo
                 .oncePerEvent(entity.getOncePerEvent())
                 .rearmWindowMinutes(entity.getRearmWindowMinutes())
                 .enabled(entity.getEnabled())
+                .createdAt(entity.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/weather/alert/infrastructure/adapter/persistence/JpaAlertCriteriaRepository.java
+++ b/src/main/java/com/weather/alert/infrastructure/adapter/persistence/JpaAlertCriteriaRepository.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 @Repository
 public interface JpaAlertCriteriaRepository extends JpaRepository<AlertCriteriaEntity, String> {
-    List<AlertCriteriaEntity> findByUserId(String userId);
+    List<AlertCriteriaEntity> findByUserIdOrderByCreatedAtAscIdAsc(String userId);
     List<AlertCriteriaEntity> findByEnabled(Boolean enabled);
 }

--- a/src/main/resources/db/migration/V16__add_alert_criteria_created_at.sql
+++ b/src/main/resources/db/migration/V16__add_alert_criteria_created_at.sql
@@ -1,0 +1,12 @@
+ALTER TABLE alert_criteria
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMP WITH TIME ZONE;
+
+UPDATE alert_criteria
+SET created_at = CURRENT_TIMESTAMP
+WHERE created_at IS NULL;
+
+ALTER TABLE alert_criteria
+    ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE alert_criteria
+    ALTER COLUMN created_at SET NOT NULL;

--- a/src/test/java/com/weather/alert/application/usecase/HandleStripeWebhookUseCaseTest.java
+++ b/src/test/java/com/weather/alert/application/usecase/HandleStripeWebhookUseCaseTest.java
@@ -1,8 +1,13 @@
 package com.weather.alert.application.usecase;
 
+import com.weather.alert.application.service.BillingPlanService;
+import com.weather.alert.domain.model.AlertCriteria;
+import com.weather.alert.domain.model.BillingEntitlements;
+import com.weather.alert.domain.model.BillingPlan;
 import com.weather.alert.domain.model.BillingWebhookEvent;
 import com.weather.alert.domain.model.BillingWebhookEventType;
 import com.weather.alert.domain.model.User;
+import com.weather.alert.domain.port.AlertCriteriaRepositoryPort;
 import com.weather.alert.domain.port.BillingProviderPort;
 import com.weather.alert.domain.port.UserRepositoryPort;
 import org.junit.jupiter.api.Test;
@@ -13,11 +18,18 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
+import java.util.List;
+import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.argThat;
 
 @ExtendWith(MockitoExtension.class)
 class HandleStripeWebhookUseCaseTest {
@@ -27,6 +39,12 @@ class HandleStripeWebhookUseCaseTest {
 
     @Mock
     private UserRepositoryPort userRepositoryPort;
+
+    @Mock
+    private AlertCriteriaRepositoryPort alertCriteriaRepositoryPort;
+
+    @Mock
+    private BillingPlanService billingPlanService;
 
     @InjectMocks
     private HandleStripeWebhookUseCase useCase;
@@ -107,5 +125,67 @@ class HandleStripeWebhookUseCaseTest {
 
         verify(userRepositoryPort, never()).findById(org.mockito.ArgumentMatchers.anyString());
         verify(userRepositoryPort, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void shouldDisableExcessCriteriaWhenDowngradedToFreePlan() {
+        User user = User.builder()
+                .id("user-1")
+                .stripeSubscriptionStatus("active")
+                .stripePriceId("price_pro")
+                .build();
+        BillingWebhookEvent event = BillingWebhookEvent.builder()
+                .type(BillingWebhookEventType.SUBSCRIPTION_DELETED)
+                .userId("user-1")
+                .build();
+        AlertCriteria oldest = AlertCriteria.builder()
+                .id("criteria-1")
+                .userId("user-1")
+                .enabled(true)
+                .createdAt(Instant.parse("2026-03-01T00:00:00Z"))
+                .build();
+        AlertCriteria second = AlertCriteria.builder()
+                .id("criteria-2")
+                .userId("user-1")
+                .enabled(true)
+                .createdAt(Instant.parse("2026-03-02T00:00:00Z"))
+                .build();
+        AlertCriteria third = AlertCriteria.builder()
+                .id("criteria-3")
+                .userId("user-1")
+                .enabled(true)
+                .createdAt(Instant.parse("2026-03-03T00:00:00Z"))
+                .build();
+
+        when(billingProviderPort.parseWebhookEvent("payload", "signature")).thenReturn(event);
+        when(userRepositoryPort.findById("user-1")).thenReturn(Optional.of(user));
+        when(billingPlanService.resolveEntitlements(any(User.class)))
+                .thenAnswer(invocation -> {
+                    User candidate = invocation.getArgument(0);
+                    if ("active".equals(candidate.getStripeSubscriptionStatus())) {
+                        return BillingEntitlements.builder()
+                                .plan(BillingPlan.PRO)
+                                .paidPlan(true)
+                                .maxActiveAlerts(50)
+                                .adSponsoredEmails(false)
+                                .build();
+                    }
+                    return BillingEntitlements.builder()
+                            .plan(BillingPlan.FREE)
+                            .paidPlan(false)
+                            .maxActiveAlerts(1)
+                            .adSponsoredEmails(true)
+                            .build();
+                });
+        when(alertCriteriaRepositoryPort.findByUserId("user-1")).thenReturn(List.of(oldest, second, third));
+
+        useCase.handle("payload", "signature");
+
+        verify(userRepositoryPort).save(argThat(savedUser -> "canceled".equals(savedUser.getStripeSubscriptionStatus())));
+        verify(alertCriteriaRepositoryPort, times(2)).save(argThat(criteria -> Boolean.FALSE.equals(criteria.getEnabled())));
+        verify(alertCriteriaRepositoryPort, never()).save(argThat(criteria -> "criteria-1".equals(criteria.getId())));
+        assertTrue(oldest.getEnabled());
+        assertFalse(second.getEnabled());
+        assertFalse(third.getEnabled());
     }
 }


### PR DESCRIPTION
## Summary
- disable excess active alert criteria when a user's plan downgrades
- preserve the oldest active alert and disable the rest instead of deleting them
- add deterministic `created_at` ordering for alert criteria

## Validation
- `mvn test -Dtest=HandleStripeWebhookUseCaseTest,ManageAlertCriteriaUseCaseTest,ApiIntegrationContractTest`
