### PR TITLE
fix: restore map-based weather alert matching

### DIFF
--- a/src/main/java/com/weather/alert/infrastructure/adapter/noaa/NoaaWeatherAdapter.java
+++ b/src/main/java/com/weather/alert/infrastructure/adapter/noaa/NoaaWeatherAdapter.java
@@ -243,10 +243,12 @@ public class NoaaWeatherAdapter implements WeatherDataPort {
     }
 
     private RequestResult<NoaaPointProperties> fetchPointProperties(double latitude, double longitude) {
+        String normalizedLatitude = String.format(Locale.US, "%.4f", latitude);
+        String normalizedLongitude = String.format(Locale.US, "%.4f", longitude);
         return requestWithFallback(
                 "point_metadata",
                 () -> noaaWebClient.get()
-                        .uri("/points/{latitude},{longitude}", latitude, longitude)
+                        .uri("/points/{latitude},{longitude}", normalizedLatitude, normalizedLongitude)
                         .retrieve()
                         .bodyToMono(NoaaPointResponse.class))
                 .mapPayload(response -> response == null ? null : response.getProperties());

--- a/src/main/resources/db/migration/V18__backfill_alert_criteria_radius.sql
+++ b/src/main/resources/db/migration/V18__backfill_alert_criteria_radius.sql
@@ -1,0 +1,5 @@
+UPDATE alert_criteria
+SET radius_km = 80
+WHERE radius_km IS NULL
+  AND latitude IS NOT NULL
+  AND longitude IS NOT NULL;

--- a/src/test/java/com/weather/alert/integration/ApiIntegrationContractTest.java
+++ b/src/test/java/com/weather/alert/integration/ApiIntegrationContractTest.java
@@ -17,6 +17,7 @@ import com.weather.alert.domain.port.AlertDeliveryDlqPublisherPort;
 import com.weather.alert.domain.port.AlertDeliveryTaskPublisherPort;
 import com.weather.alert.domain.port.AlertCriteriaRepositoryPort;
 import com.weather.alert.domain.port.NotificationPort;
+import com.weather.alert.domain.port.SmsSenderPort;
 import com.weather.alert.domain.port.WeatherDataPort;
 import com.weather.alert.domain.port.WeatherDataSearchPort;
 import com.weather.alert.domain.service.AlertProcessingService;
@@ -80,6 +81,9 @@ class ApiIntegrationContractTest {
 
     @MockBean
     private NotificationPort notificationPort;
+
+    @MockBean
+    private SmsSenderPort smsSenderPort;
 
     @MockBean
     private AlertDeliveryTaskPublisherPort alertDeliveryTaskPublisherPort;

--- a/ui/src/lib/criteria.ts
+++ b/ui/src/lib/criteria.ts
@@ -46,6 +46,7 @@ export function buildCriteriaPayload(criteriaForm: CriteriaFormState, userId: st
     location: criteriaForm.location.trim(),
     latitude: Number(criteriaForm.latitude),
     longitude: Number(criteriaForm.longitude),
+    radiusKm: Number(criteriaForm.gaugeSearchRadiusKm),
     riverGaugeId: criteriaForm.riverGaugeId.trim() || undefined,
     monitorCurrent: criteriaForm.monitorCurrent,
     monitorForecast: criteriaForm.monitorForecast,


### PR DESCRIPTION
## Summary
- send radius with map-based alert criteria so coordinate matching is active
- normalize NOAA point lookups to 4-decimal precision to avoid redirect misses
- backfill missing radius values for existing coordinate-based alerts
- add the missing SmsSenderPort mock to the integration test context

## Testing
- cd ui && npm run build
- mvn test -Dtest=ApiIntegrationContractTest,AlertProcessingServiceTest