### PR TITLE
feat: add self-serve Stripe billing portal

### DIFF
--- a/src/main/java/com/weather/alert/application/usecase/CreateBillingPortalSessionUseCase.java
+++ b/src/main/java/com/weather/alert/application/usecase/CreateBillingPortalSessionUseCase.java
@@ -1,0 +1,34 @@
+package com.weather.alert.application.usecase;
+
+import com.weather.alert.application.dto.BillingCheckoutSessionResponse;
+import com.weather.alert.application.exception.BillingStateException;
+import com.weather.alert.application.exception.UserNotFoundException;
+import com.weather.alert.domain.model.BillingCheckoutSession;
+import com.weather.alert.domain.model.User;
+import com.weather.alert.domain.port.BillingProviderPort;
+import com.weather.alert.domain.port.UserRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateBillingPortalSessionUseCase {
+
+    private final UserRepositoryPort userRepositoryPort;
+    private final BillingProviderPort billingProviderPort;
+
+    public BillingCheckoutSessionResponse createForUser(String userId) {
+        User user = userRepositoryPort.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        if (user.getStripeCustomerId() == null || user.getStripeCustomerId().isBlank()) {
+            throw new BillingStateException("User does not have a Stripe customer record");
+        }
+
+        BillingCheckoutSession session = billingProviderPort.createCustomerPortalSession(user.getStripeCustomerId());
+        return BillingCheckoutSessionResponse.builder()
+                .sessionId(session.getId())
+                .url(session.getUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/weather/alert/domain/port/BillingProviderPort.java
+++ b/src/main/java/com/weather/alert/domain/port/BillingProviderPort.java
@@ -8,5 +8,7 @@ public interface BillingProviderPort {
 
     BillingCheckoutSession createSubscriptionCheckoutSession(BillingCheckoutSessionRequest request);
 
+    BillingCheckoutSession createCustomerPortalSession(String stripeCustomerId);
+
     BillingWebhookEvent parseWebhookEvent(String payload, String signatureHeader);
 }

--- a/src/main/java/com/weather/alert/infrastructure/adapter/stripe/StripeBillingAdapter.java
+++ b/src/main/java/com/weather/alert/infrastructure/adapter/stripe/StripeBillingAdapter.java
@@ -68,6 +68,27 @@ public class StripeBillingAdapter implements BillingProviderPort {
     }
 
     @Override
+    public BillingCheckoutSession createCustomerPortalSession(String stripeCustomerId) {
+        requirePortalConfigured(stripeCustomerId);
+        try {
+            Stripe.apiKey = properties.getSecretKey();
+
+            com.stripe.model.billingportal.Session session = com.stripe.model.billingportal.Session.create(
+                    com.stripe.param.billingportal.SessionCreateParams.builder()
+                    .setCustomer(stripeCustomerId)
+                    .setReturnUrl(properties.getPortalReturnUrl())
+                    .build());
+
+            return BillingCheckoutSession.builder()
+                    .id(session.getId())
+                    .url(session.getUrl())
+                    .build();
+        } catch (StripeException ex) {
+            throw new StripeBillingException("Unable to create Stripe Customer Portal session", ex);
+        }
+    }
+
+    @Override
     public BillingWebhookEvent parseWebhookEvent(String payload, String signatureHeader) {
         requireWebhookConfigured();
         try {
@@ -148,6 +169,15 @@ public class StripeBillingAdapter implements BillingProviderPort {
     private void requireWebhookConfigured() {
         if (!properties.isEnabled()
                 || isBlank(properties.getWebhookSecret())) {
+            throw new BillingNotConfiguredException();
+        }
+    }
+
+    private void requirePortalConfigured(String stripeCustomerId) {
+        if (!properties.isEnabled()
+                || isBlank(properties.getSecretKey())
+                || isBlank(properties.getPortalReturnUrl())
+                || isBlank(stripeCustomerId)) {
             throw new BillingNotConfiguredException();
         }
     }

--- a/src/main/java/com/weather/alert/infrastructure/config/StripeBillingProperties.java
+++ b/src/main/java/com/weather/alert/infrastructure/config/StripeBillingProperties.java
@@ -17,4 +17,5 @@ public class StripeBillingProperties {
     private String priceId;
     private String successUrl = "http://localhost:5174/billing/success?session_id={CHECKOUT_SESSION_ID}";
     private String cancelUrl = "http://localhost:5174/billing/cancel";
+    private String portalReturnUrl = "http://localhost:5174/app/account";
 }

--- a/src/main/java/com/weather/alert/infrastructure/web/controller/BillingController.java
+++ b/src/main/java/com/weather/alert/infrastructure/web/controller/BillingController.java
@@ -3,6 +3,7 @@ package com.weather.alert.infrastructure.web.controller;
 import com.weather.alert.application.dto.BillingCheckoutSessionResponse;
 import com.weather.alert.application.dto.BillingStatusResponse;
 import com.weather.alert.application.dto.CreateBillingCheckoutSessionRequest;
+import com.weather.alert.application.usecase.CreateBillingPortalSessionUseCase;
 import com.weather.alert.application.exception.ForbiddenOperationException;
 import com.weather.alert.application.usecase.CreateBillingCheckoutSessionUseCase;
 import com.weather.alert.application.usecase.GetBillingStatusUseCase;
@@ -27,6 +28,7 @@ public class BillingController {
 
     private final GetBillingStatusUseCase getBillingStatusUseCase;
     private final CreateBillingCheckoutSessionUseCase createBillingCheckoutSessionUseCase;
+    private final CreateBillingPortalSessionUseCase createBillingPortalSessionUseCase;
 
     @GetMapping("/me")
     @Operation(
@@ -58,6 +60,20 @@ public class BillingController {
         return ResponseEntity.ok(createBillingCheckoutSessionUseCase.createForUser(
                 authenticatedUserId(authentication),
                 request == null ? null : request.getPlan()));
+    }
+
+    @PostMapping("/portal-session")
+    @Operation(
+            summary = "Create a Stripe Customer Portal session for subscription management",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Portal session created"),
+                    @ApiResponse(
+                            responseCode = "409",
+                            description = "User is not eligible for Stripe Customer Portal",
+                            content = @Content(mediaType = "application/problem+json"))
+            })
+    public ResponseEntity<BillingCheckoutSessionResponse> createPortalSession(Authentication authentication) {
+        return ResponseEntity.ok(createBillingPortalSessionUseCase.createForUser(authenticatedUserId(authentication)));
     }
 
     private String authenticatedUserId(Authentication authentication) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -198,3 +198,4 @@ app:
       pro-price-id: ${APP_BILLING_STRIPE_PRO_PRICE_ID:}
       success-url: ${APP_BILLING_STRIPE_SUCCESS_URL:${APP_AUTH_RECOVERY_FRONTEND_BASE_URL:http://localhost:5174}/billing/success?session_id={CHECKOUT_SESSION_ID}}
       cancel-url: ${APP_BILLING_STRIPE_CANCEL_URL:${APP_AUTH_RECOVERY_FRONTEND_BASE_URL:http://localhost:5174}/billing/cancel}
+      portal-return-url: ${APP_BILLING_STRIPE_PORTAL_RETURN_URL:${APP_AUTH_RECOVERY_FRONTEND_BASE_URL:http://localhost:5174}/app/account}

--- a/src/test/java/com/weather/alert/application/usecase/CreateBillingPortalSessionUseCaseTest.java
+++ b/src/test/java/com/weather/alert/application/usecase/CreateBillingPortalSessionUseCaseTest.java
@@ -1,0 +1,66 @@
+package com.weather.alert.application.usecase;
+
+import com.weather.alert.application.dto.BillingCheckoutSessionResponse;
+import com.weather.alert.application.exception.BillingStateException;
+import com.weather.alert.domain.model.BillingCheckoutSession;
+import com.weather.alert.domain.model.User;
+import com.weather.alert.domain.port.BillingProviderPort;
+import com.weather.alert.domain.port.UserRepositoryPort;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CreateBillingPortalSessionUseCaseTest {
+
+    @Mock
+    private UserRepositoryPort userRepositoryPort;
+
+    @Mock
+    private BillingProviderPort billingProviderPort;
+
+    @InjectMocks
+    private CreateBillingPortalSessionUseCase useCase;
+
+    @Test
+    void shouldCreatePortalSessionForExistingStripeCustomer() {
+        User user = User.builder()
+                .id("user-1")
+                .stripeCustomerId("cus_123")
+                .build();
+
+        when(userRepositoryPort.findById("user-1")).thenReturn(Optional.of(user));
+        when(billingProviderPort.createCustomerPortalSession("cus_123"))
+                .thenReturn(BillingCheckoutSession.builder()
+                        .id("bps_123")
+                        .url("https://billing.stripe.com/p/session/bps_123")
+                        .build());
+
+        BillingCheckoutSessionResponse response = useCase.createForUser("user-1");
+
+        verify(billingProviderPort).createCustomerPortalSession("cus_123");
+        assertEquals("bps_123", response.getSessionId());
+        assertEquals("https://billing.stripe.com/p/session/bps_123", response.getUrl());
+    }
+
+    @Test
+    void shouldRejectPortalSessionWhenCustomerRecordIsMissing() {
+        User user = User.builder()
+                .id("user-1")
+                .stripeCustomerId("")
+                .build();
+
+        when(userRepositoryPort.findById("user-1")).thenReturn(Optional.of(user));
+
+        assertThrows(BillingStateException.class, () -> useCase.createForUser("user-1"));
+    }
+}

--- a/src/test/java/com/weather/alert/infrastructure/config/SecurityConfigTest.java
+++ b/src/test/java/com/weather/alert/infrastructure/config/SecurityConfigTest.java
@@ -7,6 +7,7 @@ import com.weather.alert.application.dto.BillingStatusResponse;
 import com.weather.alert.application.dto.CreateAlertCriteriaRequest;
 import com.weather.alert.application.usecase.AuthenticateRegisteredUserUseCase;
 import com.weather.alert.application.usecase.CreateBillingCheckoutSessionUseCase;
+import com.weather.alert.application.usecase.CreateBillingPortalSessionUseCase;
 import com.weather.alert.application.usecase.GetBillingStatusUseCase;
 import com.weather.alert.application.usecase.HandleStripeWebhookUseCase;
 import com.weather.alert.application.usecase.ManageAccountRecoveryUseCase;
@@ -113,6 +114,9 @@ class SecurityConfigTest {
 
     @MockBean
     private CreateBillingCheckoutSessionUseCase createBillingCheckoutSessionUseCase;
+
+    @MockBean
+    private CreateBillingPortalSessionUseCase createBillingPortalSessionUseCase;
 
     @MockBean
     private HandleStripeWebhookUseCase handleStripeWebhookUseCase;
@@ -350,6 +354,19 @@ class SecurityConfigTest {
                         .with(jwt().jwt(jwt -> jwt.subject("user-1")).authorities(new SimpleGrantedAuthority("ROLE_USER"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.sessionId").value("cs_test_123"));
+    }
+
+    @Test
+    void shouldAllowAuthenticatedUserToCreateBillingPortalSession() throws Exception {
+        when(createBillingPortalSessionUseCase.createForUser("user-1")).thenReturn(BillingCheckoutSessionResponse.builder()
+                .sessionId("bps_test_123")
+                .url("https://billing.stripe.com/p/session/bps_test_123")
+                .build());
+
+        mockMvc.perform(post("/api/billing/portal-session")
+                        .with(jwt().jwt(jwt -> jwt.subject("user-1")).authorities(new SimpleGrantedAuthority("ROLE_USER"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sessionId").value("bps_test_123"));
     }
 
     @Test

--- a/src/test/java/com/weather/alert/integration/ApiIntegrationContractTest.java
+++ b/src/test/java/com/weather/alert/integration/ApiIntegrationContractTest.java
@@ -6,6 +6,7 @@ import com.weather.alert.application.dto.BillingStatusResponse;
 import com.weather.alert.domain.model.BillingPlan;
 import com.weather.alert.application.dto.JobRunResponse;
 import com.weather.alert.application.usecase.CreateBillingCheckoutSessionUseCase;
+import com.weather.alert.application.usecase.CreateBillingPortalSessionUseCase;
 import com.weather.alert.application.usecase.GetBillingStatusUseCase;
 import com.weather.alert.application.usecase.PublishDueAlertDeliveryTasksUseCase;
 import com.weather.alert.application.usecase.RunDataRetentionCleanupUseCase;
@@ -105,6 +106,9 @@ class ApiIntegrationContractTest {
 
     @MockBean
     private CreateBillingCheckoutSessionUseCase createBillingCheckoutSessionUseCase;
+
+    @MockBean
+    private CreateBillingPortalSessionUseCase createBillingPortalSessionUseCase;
 
     private OpenApiValidationFilter openApiValidationFilter;
 
@@ -208,6 +212,12 @@ class ApiIntegrationContractTest {
                 .thenReturn(BillingCheckoutSessionResponse.builder()
                         .sessionId("cs_test_weather_alerts")
                         .url("https://checkout.stripe.com/c/pay/cs_test_weather_alerts")
+                        .build());
+
+        when(createBillingPortalSessionUseCase.createForUser("test-admin"))
+                .thenReturn(BillingCheckoutSessionResponse.builder()
+                        .sessionId("bps_test_weather_alerts")
+                        .url("https://billing.stripe.com/p/session/bps_test_weather_alerts")
                         .build());
     }
 

--- a/ui/src/pages/AccountPage.tsx
+++ b/ui/src/pages/AccountPage.tsx
@@ -61,6 +61,7 @@ export function AccountPage() {
     billingStatus,
     loadingBilling,
     checkoutPlan,
+    openingBillingPortal,
     profileForm,
     setProfileForm,
     passwordForm,
@@ -71,6 +72,7 @@ export function AccountPage() {
     handleChangePassword,
     handleSaveNotificationPreference,
     handleStartCheckout,
+    handleOpenBillingPortal,
     refresh,
   } = useAppState()
   const { theme, themePreference, setThemePreference } = useThemePreference()
@@ -169,10 +171,13 @@ export function AccountPage() {
 
   function planActionLabel(planId: BillingPlan) {
     if (planId === currentPlan) {
-      return billingStatus?.activeSubscription ? 'Current plan' : 'Included'
+      return billingStatus?.activeSubscription ? 'Manage billing' : 'Included'
     }
     if (billingStatus?.activeSubscription) {
-      return 'Plan changes soon'
+      if (planId === 'FREE') {
+        return 'Downgrade in billing portal'
+      }
+      return `Change in billing portal`
     }
     if (checkoutPlan === planId) {
       return 'Redirecting...'
@@ -237,7 +242,8 @@ export function AccountPage() {
             <div className="billing-plan-grid">
               {PLAN_DETAILS.map((plan) => {
                 const isCurrentPlan = plan.id === currentPlan
-                const disableAction = isCurrentPlan || Boolean(billingStatus?.activeSubscription)
+                const usePortalAction = Boolean(billingStatus?.activeSubscription)
+                const disableAction = usePortalAction ? openingBillingPortal : isCurrentPlan || checkoutPlan !== null
                 return (
                   <article
                     key={plan.id}
@@ -262,7 +268,7 @@ export function AccountPage() {
                       </ul>
                     </div>
 
-                    {plan.id === 'FREE' ? (
+                    {plan.id === 'FREE' && !usePortalAction ? (
                       <div className="billing-plan-note">
                         <span className="small muted">
                           The Basics includes one live alert and full email or SMS delivery.
@@ -271,8 +277,8 @@ export function AccountPage() {
                     ) : (
                       <AriaButton
                         className={plan.id === 'PRO' ? 'primary button-inline' : 'ghost button-inline'}
-                        isDisabled={disableAction || checkoutPlan !== null}
-                        onPress={() => void handleStartCheckout(plan.id)}
+                        isDisabled={disableAction}
+                        onPress={() => void (usePortalAction ? handleOpenBillingPortal() : handleStartCheckout(plan.id))}
                       >
                         {planActionLabel(plan.id)}
                       </AriaButton>
@@ -285,8 +291,7 @@ export function AccountPage() {
             <div className="billing-footnote">
               {billingStatus?.activeSubscription ? (
                 <p className="small muted">
-                  Self-serve plan changes are not wired yet. Once Stripe Customer Portal is added, upgrades and downgrades
-                  will happen here instead of through support.
+                  Manage upgrades, downgrades, and cancellation in the Stripe billing portal.
                 </p>
               ) : (
                 <p className="small muted">

--- a/ui/src/state/useWeatherAppState.ts
+++ b/ui/src/state/useWeatherAppState.ts
@@ -71,6 +71,7 @@ export function useWeatherAppState() {
   const [savingProfile, setSavingProfile] = useState(false)
   const [loadingBilling, setLoadingBilling] = useState(false)
   const [checkoutPlan, setCheckoutPlan] = useState<BillingPlan | null>(null)
+  const [openingBillingPortal, setOpeningBillingPortal] = useState(false)
   const [busyAlertId, setBusyAlertId] = useState<string | null>(null)
   const [busyCriteriaId, setBusyCriteriaId] = useState<string | null>(null)
   const [busyAdminAction, setBusyAdminAction] = useState<string | null>(null)
@@ -698,6 +699,29 @@ export function useWeatherAppState() {
     }
   }
 
+  async function handleOpenBillingPortal(): Promise<boolean> {
+    if (!token) {
+      return false
+    }
+
+    setOpeningBillingPortal(true)
+    setNotice(null)
+
+    try {
+      const session = await apiRequest<BillingCheckoutSession>('/api/billing/portal-session', {
+        method: 'POST',
+        token,
+      })
+      window.location.assign(session.url)
+      return true
+    } catch (error) {
+      setNotice({ kind: 'error', text: toErrorMessage(error) })
+      return false
+    } finally {
+      setOpeningBillingPortal(false)
+    }
+  }
+
   async function handleAdminAction(userId: string, action: 'suspend' | 'reactivate' | 'force-password-reset') {
     if (!token) {
       return
@@ -781,6 +805,7 @@ export function useWeatherAppState() {
     savingProfile,
     loadingBilling,
     checkoutPlan,
+    openingBillingPortal,
     busyAlertId,
     busyCriteriaId,
     busyAdminAction,
@@ -802,6 +827,7 @@ export function useWeatherAppState() {
     handleChangePassword,
     handleSaveNotificationPreference,
     handleStartCheckout,
+    handleOpenBillingPortal,
     handleAdminAction,
 
     refresh,


### PR DESCRIPTION
## Summary
- add a Stripe customer portal session endpoint for existing subscribers
- wire the account page to open the billing portal for upgrades, downgrades, and cancellation
- keep free users on Stripe Checkout for first-time paid subscriptions

## Verification
- mvn test -Dtest=CreateBillingCheckoutSessionUseCaseTest,CreateBillingPortalSessionUseCaseTest,SecurityConfigTest,ApiIntegrationContractTest
- cd ui && npm run build