### PR TITLE
fix: harden email verification flow

### DIFF
--- a/src/main/java/com/weather/alert/application/usecase/ManageChannelVerificationUseCase.java
+++ b/src/main/java/com/weather/alert/application/usecase/ManageChannelVerificationUseCase.java
@@ -31,7 +31,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Base64;
 import java.util.HexFormat;
 import java.util.Optional;
 import java.util.UUID;
@@ -55,6 +54,9 @@ public class ManageChannelVerificationUseCase {
 
     @Value("${app.notification.verification.send-email:false}")
     private boolean sendEmail;
+
+    @Value("${app.notification.verification.frontend-base-url:http://localhost:5174}")
+    private String verificationFrontendBaseUrl;
 
     @Value("${app.notification.verification.email-subject:Weather Alert email verification}")
     private String verificationEmailSubject;
@@ -220,38 +222,33 @@ public class ManageChannelVerificationUseCase {
 
     private void sendVerificationEmail(ChannelVerification verification, String rawToken) {
         try {
+            String verificationUrl = verificationFrontendBaseUrl
+                    + "/auth/verify-email?userId="
+                    + verification.getUserId()
+                    + "&verificationId="
+                    + verification.getId();
             String body = """
                     Hi there,
 
-                    Please verify your email to finish setting up your Weather Alert account.
+                    Welcome to SkyPanda.
 
-                    Your verification code:
+                    Enter this verification code to confirm your email:
+
                     %s
 
-                    Verification details:
-                    - Verification ID: %s
-                    - Expires at: %s
+                    Or open this page to verify:
+                    %s
 
-                    If you are verifying via API, send:
+                    This code expires at %s.
 
-                    POST /api/auth/register/verify-email
-                    {
-                      "userId": "%s",
-                      "verificationId": "%s",
-                      "token": "%s"
-                    }
+                    If you did not create a SkyPanda account, you can ignore this email.
 
-                    If you did not request this, you can ignore this email.
-
-                    Weather Alert
+                    SkyPanda
                     """
                     .formatted(
                             rawToken,
-                            verification.getId(),
-                            verification.getTokenExpiresAt(),
-                            verification.getUserId(),
-                            verification.getId(),
-                            rawToken);
+                            verificationUrl,
+                            verification.getTokenExpiresAt());
 
             emailSenderPort.send(EmailMessage.builder()
                     .to(verification.getDestination())
@@ -266,13 +263,19 @@ public class ManageChannelVerificationUseCase {
     }
 
     private String generateToken() {
-        byte[] random = new byte[24];
-        SECURE_RANDOM.nextBytes(random);
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(random);
+        final char[] alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789".toCharArray();
+        StringBuilder token = new StringBuilder(9);
+        for (int index = 0; index < 8; index++) {
+            if (index == 4) {
+                token.append('-');
+            }
+            token.append(alphabet[SECURE_RANDOM.nextInt(alphabet.length)]);
+        }
+        return token.toString();
     }
 
     private String hashToken(String rawToken) {
-        return HEX_FORMAT.formatHex(sha256(rawToken));
+        return HEX_FORMAT.formatHex(sha256(normalizeToken(rawToken)));
     }
 
     private boolean tokenMatches(String rawToken, String storedTokenHash) {
@@ -280,12 +283,16 @@ public class ManageChannelVerificationUseCase {
             return false;
         }
         try {
-            byte[] candidate = sha256(rawToken);
+            byte[] candidate = sha256(normalizeToken(rawToken));
             byte[] expected = HEX_FORMAT.parseHex(storedTokenHash);
             return MessageDigest.isEqual(candidate, expected);
         } catch (IllegalArgumentException ex) {
             return false;
         }
+    }
+
+    private String normalizeToken(String rawToken) {
+        return rawToken == null ? "" : rawToken.replace("-", "").replace(" ", "").trim().toUpperCase();
     }
 
     private byte[] sha256(String value) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -157,9 +157,10 @@ app:
         api-secret: ${APP_NOTIFICATION_SMS_TWILIO_API_SECRET:}
     verification:
       token-ttl-minutes: ${APP_NOTIFICATION_VERIFICATION_TOKEN_TTL_MINUTES:15}
-      expose-raw-token: ${APP_NOTIFICATION_VERIFICATION_EXPOSE_RAW_TOKEN:true}
+      expose-raw-token: ${APP_NOTIFICATION_VERIFICATION_EXPOSE_RAW_TOKEN:false}
       send-email: ${APP_NOTIFICATION_VERIFICATION_SEND_EMAIL:false}
-      email-subject: ${APP_NOTIFICATION_VERIFICATION_EMAIL_SUBJECT:Verify your email for Weather Alert}
+      frontend-base-url: ${APP_NOTIFICATION_VERIFICATION_FRONTEND_BASE_URL:${APP_AUTH_RECOVERY_FRONTEND_BASE_URL:http://localhost:5174}}
+      email-subject: ${APP_NOTIFICATION_VERIFICATION_EMAIL_SUBJECT:Verify your email for SkyPanda}
     criteria-created:
       send-email: ${APP_NOTIFICATION_CRITERIA_CREATED_SEND_EMAIL:false}
       email-subject: ${APP_NOTIFICATION_CRITERIA_CREATED_EMAIL_SUBJECT:Your weather alert is active}

--- a/src/test/java/com/weather/alert/application/usecase/ManageChannelVerificationUseCaseTest.java
+++ b/src/test/java/com/weather/alert/application/usecase/ManageChannelVerificationUseCaseTest.java
@@ -64,6 +64,7 @@ class ManageChannelVerificationUseCaseTest {
         ReflectionTestUtils.setField(useCase, "tokenTtlMinutes", 15L);
         ReflectionTestUtils.setField(useCase, "exposeRawToken", true);
         ReflectionTestUtils.setField(useCase, "sendEmail", false);
+        ReflectionTestUtils.setField(useCase, "verificationFrontendBaseUrl", "https://app.skypanda.test");
         ReflectionTestUtils.setField(useCase, "verificationEmailSubject", "Weather Alert email verification");
     }
 
@@ -236,7 +237,7 @@ class ManageChannelVerificationUseCaseTest {
         ChannelVerificationResponse response = useCase.startVerification("dev-admin", request);
 
         assertNotNull(response.getVerificationToken());
-        assertTrue(response.getVerificationToken().length() > 20);
+        assertTrue(response.getVerificationToken().length() >= 8);
         ArgumentCaptor<ChannelVerification> captor = ArgumentCaptor.forClass(ChannelVerification.class);
         verify(channelVerificationRepository).save(captor.capture());
         assertNotNull(captor.getValue().getVerificationTokenHash());
@@ -267,6 +268,26 @@ class ManageChannelVerificationUseCaseTest {
     }
 
     @Test
+    void shouldHideRawTokenWhenExposureIsDisabled() {
+        ReflectionTestUtils.setField(useCase, "exposeRawToken", false);
+
+        StartChannelVerificationRequest request = new StartChannelVerificationRequest();
+        request.setChannel(NotificationChannel.EMAIL);
+        request.setDestination("dev-admin@example.com");
+
+        when(userRepository.findByEmail("dev-admin@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findById("dev-admin")).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(channelVerificationRepository.findByUserIdAndChannelAndDestination(
+                "dev-admin", NotificationChannel.EMAIL, "dev-admin@example.com")).thenReturn(Optional.empty());
+        when(channelVerificationRepository.save(any(ChannelVerification.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ChannelVerificationResponse response = useCase.startVerification("dev-admin", request);
+
+        assertNull(response.getVerificationToken());
+    }
+
+    @Test
     void shouldFailStartVerificationWhenEmailDeliveryFails() {
         ReflectionTestUtils.setField(useCase, "sendEmail", true);
 
@@ -293,7 +314,8 @@ class ManageChannelVerificationUseCaseTest {
     private String hash(String token) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            return HexFormat.of().formatHex(digest.digest(token.getBytes(StandardCharsets.UTF_8)));
+            String normalized = token.replace("-", "").replace(" ", "").trim().toUpperCase();
+            return HexFormat.of().formatHex(digest.digest(normalized.getBytes(StandardCharsets.UTF_8)));
         } catch (NoSuchAlgorithmException ex) {
             throw new IllegalStateException(ex);
         }

--- a/src/test/java/com/weather/alert/integration/ApiIntegrationContractTest.java
+++ b/src/test/java/com/weather/alert/integration/ApiIntegrationContractTest.java
@@ -59,6 +59,7 @@ import static org.mockito.Mockito.when;
         "app.security.admin.password=test-admin-password",
         "app.security.jwt.secret=test-jwt-signing-secret-with-minimum-length-123",
         "app.admin.jobs.token=test-admin-jobs-token",
+        "app.notification.verification.expose-raw-token=true",
         "spring.task.scheduling.enabled=false",
         "management.tracing.enabled=false"
 })

--- a/ui/src/pages/AuthVerifyEmailPage.tsx
+++ b/ui/src/pages/AuthVerifyEmailPage.tsx
@@ -1,10 +1,12 @@
-import { Link } from 'react-router-dom'
+import { useEffect } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
 import { BackgroundArtwork } from '../components/common/BackgroundArtwork'
 import { BrandLockup } from '../components/common/BrandLockup'
 import { NoticeBanner } from '../components/common/NoticeBanner'
 import { useAppState } from '../state/useAppState'
 
 export function AuthVerifyEmailPage() {
+  const [searchParams] = useSearchParams()
   const {
     notice,
     loadingAuth,
@@ -14,6 +16,20 @@ export function AuthVerifyEmailPage() {
     handleVerifyEmail,
     handleResendVerification,
   } = useAppState()
+  const queryUserId = searchParams.get('userId')?.trim() ?? ''
+  const queryVerificationId = searchParams.get('verificationId')?.trim() ?? ''
+
+  useEffect(() => {
+    if (!queryUserId && !queryVerificationId) {
+      return
+    }
+
+    setVerifyState((state) => ({
+      ...state,
+      userId: queryUserId || state.userId,
+      verificationId: queryVerificationId || state.verificationId,
+    }))
+  }, [queryUserId, queryVerificationId, setVerifyState])
 
   return (
     <div className="app-shell">
@@ -23,6 +39,7 @@ export function AuthVerifyEmailPage() {
           <div className="auth-header">
             <BrandLockup />
             <h1>Verify email</h1>
+            <p className="muted">Enter the verification code from your email to finish setting up your account.</p>
           </div>
 
           <form onSubmit={handleVerifyEmail} className="grid-form">
@@ -36,42 +53,31 @@ export function AuthVerifyEmailPage() {
               />
             </label>
             <label>
-              Verification ID
+              Verification code
               <input
                 type="text"
                 required
-                value={verifyState.verificationId}
-                onChange={(event) => setVerifyState((state) => ({ ...state, verificationId: event.target.value }))}
-              />
-            </label>
-            <label>
-              Token
-              <input
-                type="text"
-                required
+                autoComplete="one-time-code"
+                inputMode="text"
+                placeholder="ABCD-1234"
                 value={verifyState.token}
                 onChange={(event) => setVerifyState((state) => ({ ...state, token: event.target.value }))}
               />
             </label>
+            <input type="hidden" value={verifyState.verificationId} readOnly />
             <div className="button-row">
               <button type="submit" className="primary" disabled={loadingAuth}>
                 Confirm email
               </button>
               <button type="button" className="ghost" onClick={handleResendVerification} disabled={loadingAuth}>
-                Resend token
+                Resend code
               </button>
             </div>
           </form>
 
           {latestVerification ? (
             <p className="hint">
-              Latest verification: <strong>{latestVerification.id}</strong>
-              {latestVerification.verificationToken ? (
-                <>
-                  {' '}
-                  | dev token: <code>{latestVerification.verificationToken}</code>
-                </>
-              ) : null}
+              We sent a code to <strong>{latestVerification.destination}</strong>.
             </p>
           ) : null}
 

--- a/ui/src/state/useWeatherAppState.ts
+++ b/ui/src/state/useWeatherAppState.ts
@@ -267,12 +267,12 @@ export function useWeatherAppState() {
       setVerifyState({
         userId: response.account.id,
         verificationId: verification?.id ?? '',
-        token: verification?.verificationToken ?? '',
+        token: '',
       })
 
       setNotice({
         kind: 'success',
-        text: `Account ${response.account.id} created. Verify your email to sign in.`,
+        text: `Account ${response.account.id} created. Check your email for your verification code.`,
       })
       setRegisterState(initialRegister)
     } catch (error) {
@@ -321,10 +321,11 @@ export function useWeatherAppState() {
       setLatestVerification(verification)
       setVerifyState((current) => ({
         ...current,
+        userId: username,
         verificationId: verification.id,
-        token: verification.verificationToken ?? current.token,
+        token: '',
       }))
-      setNotice({ kind: 'success', text: `Verification resent for ${username}.` })
+      setNotice({ kind: 'success', text: `A fresh verification code was sent for ${username}.` })
     } catch (error) {
       setNotice({ kind: 'error', text: toErrorMessage(error) })
     } finally {


### PR DESCRIPTION
## Summary
- stop exposing raw verification tokens by default and switch to a short human-friendly code
- update the verification email and verify-email screen to use a simple code-entry flow
- keep verification IDs internal to the UI while preserving direct email-link handoff

## Verification
- mvn test -Dtest=ManageChannelVerificationUseCaseTest,ManageUserAccountUseCaseTest,ApiIntegrationContractTest
- cd ui && npm run build