### PR TITLE
feat: add public compliance and privacy pages

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,12 +7,14 @@ import { AuthForgotPasswordPage } from './pages/AuthForgotPasswordPage'
 import { AuthForgotUsernamePage } from './pages/AuthForgotUsernamePage'
 import { AuthLandingPage } from './pages/AuthLandingPage'
 import { AuthLoginPage } from './pages/AuthLoginPage'
+import { PrivacyPolicyPage } from './pages/PrivacyPolicyPage'
 import { AuthRegisterPage } from './pages/AuthRegisterPage'
 import { AuthVerifyEmailPage } from './pages/AuthVerifyEmailPage'
 import { EventsPage } from './pages/EventsPage'
 import { ManageAlertsPage } from './pages/ManageAlertsPage'
 import { OverviewPage } from './pages/OverviewPage'
 import { RulesPage } from './pages/RulesPage'
+import { SmsConsentPage } from './pages/SmsConsentPage'
 import { AppStateProvider } from './state/AppStateContext'
 import { useAppState } from './state/useAppState'
 
@@ -55,6 +57,8 @@ function AppRoutes() {
       <Route path="/" element={<RootRedirect />} />
       <Route path="/billing/success" element={<BillingRedirect status="success" />} />
       <Route path="/billing/cancel" element={<BillingRedirect status="cancel" />} />
+      <Route path="/privacy-policy" element={<PrivacyPolicyPage />} />
+      <Route path="/sms-consent" element={<SmsConsentPage />} />
       <Route path="/auth" element={<AuthRoute />}>
         <Route index element={<AuthLandingPage />} />
         <Route path="login" element={<AuthLoginPage />} />

--- a/ui/src/components/layout/PublicInfoLayout.tsx
+++ b/ui/src/components/layout/PublicInfoLayout.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { BackgroundArtwork } from '../common/BackgroundArtwork'
+import { BrandLockup } from '../common/BrandLockup'
+
+interface PublicInfoLayoutProps {
+  eyebrow: string
+  title: string
+  summary: string
+  children: ReactNode
+}
+
+export function PublicInfoLayout({ eyebrow, title, summary, children }: PublicInfoLayoutProps) {
+  return (
+    <div className="app-shell">
+      <BackgroundArtwork />
+      <main className="public-info-layout">
+        <section className="panel public-info-panel">
+          <div className="public-info-header">
+            <BrandLockup compact />
+            <p className="eyebrow">{eyebrow}</p>
+            <h1>{title}</h1>
+            <p className="muted public-info-summary">{summary}</p>
+          </div>
+
+          <div className="public-info-content">{children}</div>
+
+          <div className="auth-link-row public-info-links">
+            <Link className="auth-link" to="/">
+              Back to home
+            </Link>
+            <Link className="auth-link" to="/privacy-policy">
+              Privacy policy
+            </Link>
+            <Link className="auth-link" to="/sms-consent">
+              SMS consent
+            </Link>
+          </div>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/ui/src/pages/AuthLandingPage.tsx
+++ b/ui/src/pages/AuthLandingPage.tsx
@@ -128,6 +128,15 @@ export function AuthLandingPage() {
               ))}
             </div>
           </section>
+
+          <div className="auth-link-row auth-home-legal-links">
+            <Link className="auth-link" to="/sms-consent">
+              SMS consent
+            </Link>
+            <Link className="auth-link" to="/privacy-policy">
+              Privacy policy
+            </Link>
+          </div>
         </section>
       </main>
     </div>

--- a/ui/src/pages/PrivacyPolicyPage.tsx
+++ b/ui/src/pages/PrivacyPolicyPage.tsx
@@ -1,0 +1,75 @@
+import { PublicInfoLayout } from '../components/layout/PublicInfoLayout'
+
+export function PrivacyPolicyPage() {
+  return (
+    <PublicInfoLayout
+      eyebrow="Policy"
+      title="SkyPanda Privacy Policy"
+      summary="This page explains what information SkyPanda collects, how it is used to deliver weather monitoring and alerts, and how users can manage their data."
+    >
+      <section className="public-info-section">
+        <h2>Information we collect</h2>
+        <ul className="public-info-list">
+          <li>Account details such as username, email address, password hash, and optional phone number.</li>
+          <li>Monitoring preferences, alert rules, saved locations, and delivery-channel choices.</li>
+          <li>Operational message history such as alerts sent, acknowledgements, and delivery outcomes.</li>
+          <li>Technical and security metadata needed to protect accounts and operate the service.</li>
+        </ul>
+      </section>
+
+      <section className="public-info-section">
+        <h2>How we use information</h2>
+        <ul className="public-info-list">
+          <li>Provide weather monitoring, alerting, and account access.</li>
+          <li>Deliver requested email and SMS notifications.</li>
+          <li>Improve reliability, security, and abuse prevention.</li>
+          <li>Maintain billing, subscription, and support workflows.</li>
+        </ul>
+      </section>
+
+      <section className="public-info-section">
+        <h2>SMS and communications data</h2>
+        <p>
+          Phone numbers and SMS consent records are used only for the alerting and verification workflows the user enabled.
+          SkyPanda does not sell SMS opt-in data or consent records. Text messaging originators and delivery providers may
+          process message metadata solely to deliver requested messages.
+        </p>
+      </section>
+
+      <section className="public-info-section">
+        <h2>Sharing</h2>
+        <p>
+          SkyPanda shares data only with service providers needed to run the product, such as cloud hosting, email, SMS,
+          mapping, authentication, and billing providers. Those providers only receive the information required for their
+          function.
+        </p>
+      </section>
+
+      <section className="public-info-section">
+        <h2>Retention</h2>
+        <p>
+          SkyPanda keeps account and alert data for as long as needed to operate the account, meet security and billing
+          obligations, and support user-requested monitoring. Some operational weather and alert records may be removed on a
+          rolling retention schedule.
+        </p>
+      </section>
+
+      <section className="public-info-section">
+        <h2>User choices</h2>
+        <ul className="public-info-list">
+          <li>Users can edit alert rules, delivery settings, and profile details from their account.</li>
+          <li>Users can disable SMS delivery or reply STOP to opt out of text messages.</li>
+          <li>Users can use email-only delivery if they do not want SMS.</li>
+        </ul>
+      </section>
+
+      <section className="public-info-section">
+        <h2>Contact</h2>
+        <p>
+          Questions about this policy or messaging practices should be directed through the SkyPanda account and support
+          channels.
+        </p>
+      </section>
+    </PublicInfoLayout>
+  )
+}

--- a/ui/src/pages/SmsConsentPage.tsx
+++ b/ui/src/pages/SmsConsentPage.tsx
@@ -1,0 +1,91 @@
+import { Link } from 'react-router-dom'
+import { PublicInfoLayout } from '../components/layout/PublicInfoLayout'
+
+const CONSENT_STEPS = [
+  'Create a SkyPanda account with a valid email address.',
+  'Add a phone number to your account profile.',
+  'Enable SMS in delivery preferences and choose SMS as an available alert channel.',
+  'Save your preferences and keep at least one monitoring rule active for the locations you want watched.',
+]
+
+const MESSAGE_TYPES = [
+  'Weather alert notifications tied to the rules you created in SkyPanda.',
+  'Important account or delivery notices related to your alert setup.',
+  'Verification or security messages when you request them.',
+]
+
+export function SmsConsentPage() {
+  return (
+    <PublicInfoLayout
+      eyebrow="Compliance"
+      title="SkyPanda SMS consent and program terms"
+      summary="This public page explains how SkyPanda collects consent for SMS weather alerts and what subscribers can expect when they opt in."
+    >
+      <section className="public-info-section">
+        <h2>How consent is collected</h2>
+        <p>
+          SkyPanda only sends SMS messages after the account owner actively enables SMS delivery inside the product. A user
+          must complete all of these steps before receiving text alerts:
+        </p>
+        <ol className="public-info-list public-info-list-ordered">
+          {CONSENT_STEPS.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ol>
+        <p>
+          SMS consent is not a condition of purchase. Users can keep using SkyPanda with email-only delivery if they do not
+          want text messages.
+        </p>
+      </section>
+
+      <section className="public-info-section">
+        <h2>Consent language shown to users</h2>
+        <div className="public-info-callout">
+          <strong>Example disclosure</strong>
+          <p>
+            By enabling SMS delivery, you agree to receive SkyPanda weather alert text messages for the monitoring rules on
+            your account. Message frequency varies based on weather conditions and your saved alerts. Message and data rates
+            may apply. Reply <strong>STOP</strong> to opt out and <strong>HELP</strong> for help.
+          </p>
+        </div>
+      </section>
+
+      <section className="public-info-section">
+        <h2>What messages are sent</h2>
+        <ul className="public-info-list">
+          {MESSAGE_TYPES.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="public-info-section">
+        <h2>Message frequency</h2>
+        <p>
+          Message frequency varies. It depends on the alert rules a user creates, the number of monitored locations, and
+          actual weather activity affecting those locations.
+        </p>
+      </section>
+
+      <section className="public-info-section">
+        <h2>Opt-out and help</h2>
+        <p>
+          Users can reply <strong>STOP</strong> to end SMS messages at any time. Users can reply <strong>HELP</strong> for
+          assistance, or contact SkyPanda support through the product account area.
+        </p>
+      </section>
+
+      <section className="public-info-section">
+        <h2>Privacy</h2>
+        <p>
+          SkyPanda uses phone numbers and alert preferences only to deliver and manage requested messages. For more detail,
+          review the{' '}
+          <Link className="auth-link" to="/privacy-policy">
+            SkyPanda Privacy Policy
+          </Link>
+          .
+        </p>
+      </section>
+    </PublicInfoLayout>
+  )
+}

--- a/ui/src/styles/common.css
+++ b/ui/src/styles/common.css
@@ -328,6 +328,10 @@
   gap: 0.75rem;
 }
 
+.auth-home-legal-links {
+  padding-top: 0.25rem;
+}
+
 .auth-home-example-card {
   display: grid;
   gap: 0.32rem;
@@ -369,6 +373,87 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.65rem;
+}
+
+.public-info-layout {
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+.public-info-panel {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.public-info-header {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.public-info-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-family: var(--font-heading);
+}
+
+.public-info-summary {
+  margin: 0;
+  max-width: 68ch;
+}
+
+.public-info-content {
+  display: grid;
+  gap: 1rem;
+}
+
+.public-info-section {
+  display: grid;
+  gap: 0.55rem;
+  padding: 1rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 1rem;
+  background: var(--card-bg);
+  box-shadow: var(--card-shadow-soft);
+}
+
+.public-info-section h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.public-info-section p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.public-info-list {
+  margin: 0;
+  padding-left: 1.15rem;
+  color: var(--text-secondary);
+  display: grid;
+  gap: 0.45rem;
+}
+
+.public-info-list-ordered {
+  padding-left: 1.3rem;
+}
+
+.public-info-callout {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.95rem 1rem;
+  border-radius: 0.95rem;
+  border: 1px solid var(--panel-border-strong);
+  background: var(--card-bg-highlight);
+}
+
+.public-info-callout strong {
+  font-family: var(--font-heading);
+}
+
+.public-info-links {
+  justify-content: space-between;
 }
 
 .feature-list {


### PR DESCRIPTION
## Summary
- add public unauthenticated SMS consent and privacy policy pages
- expose stable routes for carrier/compliance review without requiring login
- link the public pages from the landing experience for discoverability

## Verification
- cd ui && npm run build