### PR TITLE
fix: raise overview forecast strip above bottom nav

### DIFF
--- a/ui/src/styles/dashboard.css
+++ b/ui/src/styles/dashboard.css
@@ -1480,7 +1480,7 @@ button.overview-official-alert-card:disabled {
   margin-left: auto;
   margin-right: auto;
   transform: none;
-  bottom: calc(3.95rem + env(safe-area-inset-bottom));
+  bottom: calc(var(--bottom-nav-content-clearance) + 0.55rem);
   z-index: 30;
   box-sizing: border-box;
   margin-bottom: 0;

--- a/ui/src/styles/responsive.css
+++ b/ui/src/styles/responsive.css
@@ -402,7 +402,7 @@
     width: auto;
     max-width: calc(100vw - 1.9rem);
     transform: none;
-    bottom: calc(3.95rem + env(safe-area-inset-bottom));
+    bottom: calc(var(--bottom-nav-content-clearance) + 0.5rem);
     z-index: 30;
     box-sizing: border-box;
   }
@@ -677,7 +677,7 @@
     right: 0.7rem;
     width: auto;
     transform: none;
-    bottom: calc(3.85rem + env(safe-area-inset-bottom));
+    bottom: calc(var(--bottom-nav-content-clearance) + 0.35rem);
   }
 
   .overview-minimal-forecast-row {


### PR DESCRIPTION
## Summary
- align the overview forecast strip with the shared bottom-nav clearance variable
- remove hard-coded forecast strip offsets that could clip under the mobile nav
- keep the forecast strip visually above the nav across device sizes

## Testing
- mvn test
- cd ui && npm ci && npm run lint && npm run build