### PR TITLE
fix: improve overview forecast strip mobile clearance

### DIFF
--- a/ui/src/styles/dashboard.css
+++ b/ui/src/styles/dashboard.css
@@ -1480,7 +1480,7 @@ button.overview-official-alert-card:disabled {
   margin-left: auto;
   margin-right: auto;
   transform: none;
-  bottom: calc(var(--bottom-nav-content-clearance) + 0.55rem);
+  bottom: calc(var(--bottom-nav-content-clearance) + 0.9rem);
   z-index: 30;
   box-sizing: border-box;
   margin-bottom: 0;

--- a/ui/src/styles/responsive.css
+++ b/ui/src/styles/responsive.css
@@ -391,7 +391,7 @@
 
   .overview-minimal-forecast-strip {
     margin-bottom: 0;
-    padding: 0.6rem;
+    padding: 0.52rem;
     border-radius: 1.15rem;
   }
 
@@ -402,34 +402,38 @@
     width: auto;
     max-width: calc(100vw - 1.9rem);
     transform: none;
-    bottom: calc(var(--bottom-nav-content-clearance) + 0.5rem);
+    bottom: calc(var(--bottom-nav-content-clearance) + 0.95rem);
     z-index: 30;
     box-sizing: border-box;
   }
 
   .overview-minimal-forecast-row {
-    gap: 0.34rem;
+    gap: 0.28rem;
     grid-auto-columns: minmax(3.85rem, 1fr);
   }
 
   .overview-minimal-forecast-item {
-    padding: 0.2rem 0.2rem;
+    gap: 0.16rem;
+    padding: 0.12rem 0.18rem;
   }
 
   .overview-minimal-forecast-label {
     font-size: 0.78rem;
+    line-height: 1.05;
   }
 
   .overview-minimal-forecast-temp {
     font-size: 1.02rem;
+    line-height: 1.02;
   }
 
   .overview-minimal-forecast-icon {
-    font-size: 1.22rem;
+    font-size: 1.18rem;
   }
 
   .overview-minimal-forecast-precip {
     font-size: 0.69rem;
+    line-height: 1.02;
   }
 
   .nws-products-hero {
@@ -668,7 +672,7 @@
 
   .overview-minimal-forecast-strip {
     margin-bottom: 0;
-    padding: 0.5rem;
+    padding: 0.44rem;
     border-radius: 1rem;
   }
 
@@ -677,7 +681,7 @@
     right: 0.7rem;
     width: auto;
     transform: none;
-    bottom: calc(var(--bottom-nav-content-clearance) + 0.35rem);
+    bottom: calc(var(--bottom-nav-content-clearance) + 0.8rem);
   }
 
   .overview-minimal-forecast-row {


### PR DESCRIPTION
## Summary
- raise the overview forecast strip farther above the bottom nav on immersive mobile screens
- tighten the mobile forecast strip spacing so the precipitation row has more room
- keep the overview forecast visible on shorter phones where the old layout clipped the last line

## Testing
- cd ui && npm run lint