### PR TITLE
feat: refine mobile ui polish and shared icon system

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ui",
       "version": "0.0.0",
       "dependencies": {
+        "lucide-react": "^0.577.0",
         "maplibre-gl": "^5.20.1",
         "react": "^19.2.0",
         "react-aria-components": "^1.15.1",
@@ -4875,6 +4876,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/maplibre-gl": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "lucide-react": "^0.577.0",
     "maplibre-gl": "^5.20.1",
     "react": "^19.2.0",
     "react-aria-components": "^1.15.1",

--- a/ui/src/components/features/dashboard/ActiveAlertCard.tsx
+++ b/ui/src/components/features/dashboard/ActiveAlertCard.tsx
@@ -37,8 +37,8 @@ export function ActiveAlertCard({ item, busy, onAcknowledge }: ActiveAlertCardPr
 
       {item.metrics.length > 0 ? (
         <div className="alert-metrics">
-          {item.metrics.map((metric) => (
-            <span key={`${metric.icon}-${metric.label}`} className="metric-pill">
+          {item.metrics.map((metric, index) => (
+            <span key={`${metric.label}-${index}`} className="metric-pill">
               <span aria-hidden>{metric.icon}</span>
               <span>{metric.label}</span>
             </span>

--- a/ui/src/components/features/dashboard/AlertTimelineItem.tsx
+++ b/ui/src/components/features/dashboard/AlertTimelineItem.tsx
@@ -24,8 +24,8 @@ export function AlertTimelineItem({ item }: AlertTimelineItemProps) {
 
       {item.metrics.length > 0 ? (
         <div className="alert-timeline-chips">
-          {item.metrics.slice(0, 3).map((metric) => (
-            <span key={`${metric.icon}-${metric.label}`} className="metric-pill">
+          {item.metrics.slice(0, 3).map((metric, index) => (
+            <span key={`${metric.label}-${index}`} className="metric-pill">
               <span aria-hidden>{metric.icon}</span>
               <span>{metric.label}</span>
             </span>

--- a/ui/src/components/features/dashboard/DailyForecastStrip.tsx
+++ b/ui/src/components/features/dashboard/DailyForecastStrip.tsx
@@ -1,4 +1,7 @@
+import { Droplets } from 'lucide-react'
+import { renderAppIcon } from '../../../lib/appIcons'
 import { formatTemperature, formatPercentOrNA } from '../../../lib/formatting'
+import { resolveWeatherVisual } from '../../../lib/weatherVisuals'
 import type { WeatherCondition } from '../../../types'
 
 interface DailyForecastStripProps {
@@ -59,32 +62,8 @@ function buildUniqueDailyItems(items: WeatherCondition[]): WeatherCondition[] {
     .slice(0, 7)
 }
 
-function resolveWeatherIcon(item: WeatherCondition): string {
-  if (item.probabilityOfThunder != null && item.probabilityOfThunder > 30) {
-    return '⛈'
-  }
-  if ((item.precipitationProbability ?? 0) > 60) {
-    return '🌧'
-  }
-  if ((item.precipitationProbability ?? 0) > 30) {
-    return '🌦'
-  }
-  if ((item.skyCover ?? 0) > 75) {
-    return '☁️'
-  }
-  if ((item.skyCover ?? 0) > 40) {
-    return '⛅'
-  }
-  return '☀️'
-}
-
 function resolveWeatherLabel(item: WeatherCondition): string {
-  if (item.probabilityOfThunder != null && item.probabilityOfThunder > 30) return 'Thunderstorm'
-  if ((item.precipitationProbability ?? 0) > 60) return 'Rain'
-  if ((item.precipitationProbability ?? 0) > 30) return 'Partly rainy'
-  if ((item.skyCover ?? 0) > 75) return 'Cloudy'
-  if ((item.skyCover ?? 0) > 40) return 'Partly cloudy'
-  return 'Sunny'
+  return resolveWeatherVisual(item).label
 }
 
 export function DailyForecastStrip({ items, unit = 'F' }: DailyForecastStripProps) {
@@ -110,10 +89,13 @@ export function DailyForecastStrip({ items, unit = 'F' }: DailyForecastStripProp
             <div key={item.id} className={`daily-forecast-day${today ? ' daily-forecast-day--today' : ''}`}>
               <span className="daily-forecast-day-label">{today ? 'Today' : formatDayLabel(item)}</span>
               <span className="daily-forecast-day-icon" role="img" aria-label={resolveWeatherLabel(item)}>
-                {resolveWeatherIcon(item)}
+                {resolveWeatherVisual(item).icon}
               </span>
               <span className="daily-forecast-day-temp">{formatTemperature(item.temperature, unit)}</span>
-              <span className="daily-forecast-day-rain">💧 {formatPercentOrNA(item.precipitationProbability)}</span>
+              <span className="daily-forecast-day-rain">
+                <span className="forecast-precip-icon" aria-hidden>{renderAppIcon(Droplets, 'app-icon-glyph forecast-precip-glyph')}</span>
+                <span>{formatPercentOrNA(item.precipitationProbability)}</span>
+              </span>
             </div>
           )
         })}

--- a/ui/src/components/features/dashboard/HourlyForecastStrip.tsx
+++ b/ui/src/components/features/dashboard/HourlyForecastStrip.tsx
@@ -1,4 +1,7 @@
+import { Droplets } from 'lucide-react'
+import { renderAppIcon } from '../../../lib/appIcons'
 import { formatTemperature, formatPercentOrNA } from '../../../lib/formatting'
+import { resolveWeatherVisual } from '../../../lib/weatherVisuals'
 import type { WeatherCondition } from '../../../types'
 
 interface HourlyForecastStripProps {
@@ -22,22 +25,8 @@ function formatHourLabel(item: WeatherCondition): string {
   return date.toLocaleTimeString(undefined, { hour: 'numeric' })
 }
 
-function resolveWeatherIcon(item: WeatherCondition): string {
-  if (item.probabilityOfThunder != null && item.probabilityOfThunder > 30) return '⛈'
-  if ((item.precipitationProbability ?? 0) > 60) return '🌧'
-  if ((item.precipitationProbability ?? 0) > 30) return '🌦'
-  if ((item.skyCover ?? 0) > 75) return '☁️'
-  if ((item.skyCover ?? 0) > 40) return '⛅'
-  return '☀️'
-}
-
 function resolveWeatherLabel(item: WeatherCondition): string {
-  if (item.probabilityOfThunder != null && item.probabilityOfThunder > 30) return 'Thunderstorm'
-  if ((item.precipitationProbability ?? 0) > 60) return 'Rain'
-  if ((item.precipitationProbability ?? 0) > 30) return 'Partly rainy'
-  if ((item.skyCover ?? 0) > 75) return 'Cloudy'
-  if ((item.skyCover ?? 0) > 40) return 'Partly cloudy'
-  return 'Sunny'
+  return resolveWeatherVisual(item).label
 }
 
 export function HourlyForecastStrip({ items, unit = 'F' }: HourlyForecastStripProps) {
@@ -57,9 +46,12 @@ export function HourlyForecastStrip({ items, unit = 'F' }: HourlyForecastStripPr
         {items.slice(0, 24).map((item) => (
           <div key={item.id} className="hourly-forecast-slot">
             <span className="hourly-forecast-time">{formatHourLabel(item)}</span>
-            <span className="hourly-forecast-icon" role="img" aria-label={resolveWeatherLabel(item)}>{resolveWeatherIcon(item)}</span>
+            <span className="hourly-forecast-icon" role="img" aria-label={resolveWeatherLabel(item)}>{resolveWeatherVisual(item).icon}</span>
             <span className="hourly-forecast-temp">{formatTemperature(item.temperature, unit)}</span>
-            <span className="hourly-forecast-rain">💧 {formatPercentOrNA(item.precipitationProbability)}</span>
+            <span className="hourly-forecast-rain">
+              <span className="forecast-precip-icon" aria-hidden>{renderAppIcon(Droplets, 'app-icon-glyph forecast-precip-glyph')}</span>
+              <span>{formatPercentOrNA(item.precipitationProbability)}</span>
+            </span>
           </div>
         ))}
       </div>

--- a/ui/src/components/features/dashboard/NwsProductsPanel.tsx
+++ b/ui/src/components/features/dashboard/NwsProductsPanel.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { BellRing, FileText, NotebookText, Radio, TriangleAlert } from 'lucide-react'
+import { renderAppIcon } from '../../../lib/appIcons'
 import type { NwsProduct } from '../../../types'
 
 interface NwsProductsPanelProps {
@@ -60,18 +62,18 @@ function extractDiscussionExcerpt(productText?: string): string {
   return body ? truncateCopy(body, 280) : 'Open the latest discussion for the full NWS narrative forecast.'
 }
 
-function resolveProductIcon(productCode?: string): string {
+function resolveProductIcon(productCode?: string) {
   switch (productCode) {
     case 'AFD':
-      return '📋'
+      return renderAppIcon(NotebookText)
     case 'HWO':
-      return '⚠️'
+      return renderAppIcon(TriangleAlert)
     case 'SPS':
-      return '🔔'
+      return renderAppIcon(BellRing)
     case 'LSR':
-      return '📡'
+      return renderAppIcon(Radio)
     default:
-      return '📄'
+      return renderAppIcon(FileText)
   }
 }
 

--- a/ui/src/components/features/dashboard/OverviewLocationSwitcher.tsx
+++ b/ui/src/components/features/dashboard/OverviewLocationSwitcher.tsx
@@ -1,8 +1,6 @@
 import { lazy, Suspense, useEffect, useId, useRef, useState } from 'react'
 import { usePlaceSearch } from '../../../hooks/usePlaceSearch'
 import { formatFriendlyLocation } from '../../../lib/formatting'
-import { reverseGeocode } from '../../../services/geocoding'
-import { AriaButton } from '../../ui/AriaButton'
 
 const LocationPickerMap = lazy(() =>
   import('../../maps/LocationPickerMap').then((module) => ({ default: module.LocationPickerMap })),
@@ -33,25 +31,16 @@ export function OverviewLocationSwitcher({
   const searchInputRef = useRef<HTMLInputElement | null>(null)
 
   const [isOpen, setIsOpen] = useState(false)
-  const [resolvingCurrentLocation, setResolvingCurrentLocation] = useState(false)
   const [saving, setSaving] = useState(false)
   const [showTooltip, setShowTooltip] = useState(false)
   const [query, setQuery] = useState(activeLocation.name)
   const [draftLocation, setDraftLocation] = useState(activeLocation)
   const [hasTypedQuery, setHasTypedQuery] = useState(false)
-  const [locationError, setLocationError] = useState<string | null>(null)
   const {
     results,
-    searching,
-    searchError,
     clearResults,
     skipNextSearchFor,
   } = usePlaceSearch(query, { debounceMs: 320, enabled: isOpen && hasTypedQuery })
-
-  const isViewingCustomLocation =
-    Math.abs(activeLocation.latitude - monitoringLocation.latitude) > 0.0001 ||
-    Math.abs(activeLocation.longitude - monitoringLocation.longitude) > 0.0001 ||
-    formatFriendlyLocation(activeLocation.name) !== formatFriendlyLocation(monitoringLocation.name)
 
   useEffect(() => {
     if (!isOpen) {
@@ -62,7 +51,6 @@ export function OverviewLocationSwitcher({
     clearResults()
     setDraftLocation(activeLocation)
     setHasTypedQuery(false)
-    setLocationError(null)
 
     const timeoutId = window.setTimeout(() => {
       searchInputRef.current?.focus()
@@ -99,8 +87,6 @@ export function OverviewLocationSwitcher({
   function closeModal() {
     setIsOpen(false)
     clearResults()
-    setResolvingCurrentLocation(false)
-    setLocationError(null)
   }
 
   function applyDraftLocation(location: OverviewLocationSelection) {
@@ -109,7 +95,6 @@ export function OverviewLocationSwitcher({
     skipNextSearchFor(location.name)
     clearResults()
     setHasTypedQuery(false)
-    setLocationError(null)
   }
 
   function beginTooltipLongPress() {
@@ -130,48 +115,17 @@ export function OverviewLocationSwitcher({
     setShowTooltip(false)
   }
 
-  async function handleUseCurrentLocation() {
-    if (!navigator.geolocation) {
-      setLocationError('Current location is not available on this device.')
+  async function commitSelection(location: OverviewLocationSelection) {
+    if (saving) {
       return
     }
 
-    setResolvingCurrentLocation(true)
-    clearResults()
-    setLocationError(null)
-
-    try {
-      const position = await new Promise<GeolocationPosition>((resolve, reject) => {
-        navigator.geolocation.getCurrentPosition(resolve, reject, {
-          enableHighAccuracy: true,
-          timeout: 10_000,
-          maximumAge: 60_000,
-        })
-      })
-
-      const latitude = position.coords.latitude
-      const longitude = position.coords.longitude
-      const place = await reverseGeocode(latitude, longitude)
-
-      applyDraftLocation({
-        name: place?.name ?? 'Current location',
-        detail: place?.displayName,
-        latitude,
-        longitude,
-      })
-    } catch {
-      setLocationError('SkyPanda could not read your current location.')
-    } finally {
-      setResolvingCurrentLocation(false)
-    }
-  }
-
-  async function handleSave() {
+    applyDraftLocation(location)
+    setIsOpen(false)
     setSaving(true)
 
     try {
-      await onSaveLocation(draftLocation)
-      closeModal()
+      await onSaveLocation(location)
     } finally {
       setSaving(false)
     }
@@ -227,37 +181,45 @@ export function OverviewLocationSwitcher({
             role="dialog"
           >
             <div className="overview-location-dialog-header">
-              <div>
-                <h2 id={`${titleId}-dialog`}>Change location</h2>
-                <p className="overview-location-dialog-copy">
-                  Search or tap the map to update the weather shown here.
-                </p>
-              </div>
-              <AriaButton className="ghost button-inline overview-location-close" onPress={closeModal}>
-                Close
-              </AriaButton>
+              <h2 id={`${titleId}-dialog`}>Choose location</h2>
+              <button className="overview-location-close" aria-label="Close location picker" onClick={closeModal} type="button">
+                ✕
+              </button>
             </div>
 
             <div className="overview-location-picker-grid">
               <div className="overview-location-search-column">
+                <div className="overview-location-selection-card">
+                  <span className="overview-location-selection-label">Selected area</span>
+                  <strong>{formatFriendlyLocation(draftLocation.name || monitoringLocation.name)}</strong>
+                </div>
+
                 <div className="overview-location-search-wrapper">
-                  <label className="overview-location-search-field" htmlFor={`${titleId}-search`}>
-                    <span>Find a place</span>
-                    <input
-                      ref={searchInputRef}
-                      autoComplete="off"
-                      className="travel-input overview-location-search-input"
-                      id={`${titleId}-search`}
-                      maxLength={180}
-                      onChange={(event) => {
-                        setHasTypedQuery(true)
-                        setQuery(event.target.value)
-                        setLocationError(null)
-                      }}
-                      placeholder="City, ZIP, landmark"
-                      value={query}
-                    />
-                  </label>
+                  <input
+                    ref={searchInputRef}
+                    aria-label="Find a place"
+                    autoComplete="off"
+                    className="travel-input overview-location-search-input"
+                    id={`${titleId}-search`}
+                    maxLength={180}
+                    onChange={(event) => {
+                      setHasTypedQuery(true)
+                      setQuery(event.target.value)
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' && results[0]) {
+                        event.preventDefault()
+                        void commitSelection({
+                          name: results[0].name,
+                          detail: results[0].displayName,
+                          latitude: results[0].latitude,
+                          longitude: results[0].longitude,
+                        })
+                      }
+                    }}
+                    placeholder="Find a place"
+                    value={query}
+                  />
 
                   {results.length > 0 ? (
                     <ul className="travel-geo-results overview-location-results">
@@ -266,7 +228,7 @@ export function OverviewLocationSwitcher({
                           <button
                             className="travel-geo-result"
                             onClick={() =>
-                              applyDraftLocation({
+                              void commitSelection({
                                 name: item.name,
                                 detail: item.displayName,
                                 latitude: item.latitude,
@@ -283,34 +245,6 @@ export function OverviewLocationSwitcher({
                     </ul>
                   ) : null}
                 </div>
-
-                <div className="overview-location-search-actions">
-                  <AriaButton
-                    className="ghost button-inline overview-location-action"
-                    isDisabled={resolvingCurrentLocation}
-                    onPress={() => void handleUseCurrentLocation()}
-                  >
-                    {resolvingCurrentLocation ? 'Locating...' : 'Use current location'}
-                  </AriaButton>
-                  {isViewingCustomLocation ? (
-                    <AriaButton
-                      className="ghost button-inline overview-location-action"
-                      isDisabled={saving}
-                      onPress={() => applyDraftLocation(monitoringLocation)}
-                    >
-                      Use monitored location
-                    </AriaButton>
-                  ) : null}
-                </div>
-
-                {searching ? <p className="muted small overview-location-status">Finding places…</p> : null}
-                {locationError ?? searchError ? <p className="field-error">{locationError ?? searchError}</p> : null}
-
-                <div className="overview-location-selection-card">
-                  <span className="overview-location-selection-label">Selected location</span>
-                  <strong>{formatFriendlyLocation(draftLocation.name)}</strong>
-                  <span>{draftLocation.detail ?? `${draftLocation.latitude.toFixed(3)}, ${draftLocation.longitude.toFixed(3)}`}</span>
-                </div>
               </div>
 
               <div className="overview-location-map-panel">
@@ -320,7 +254,7 @@ export function OverviewLocationSwitcher({
                     location={draftLocation.name}
                     longitude={draftLocation.longitude}
                     onSelect={({ location, latitude, longitude }) => {
-                      applyDraftLocation({
+                      void commitSelection({
                         name: location,
                         latitude,
                         longitude,
@@ -330,15 +264,6 @@ export function OverviewLocationSwitcher({
                   />
                 </Suspense>
               </div>
-            </div>
-
-            <div className="overview-location-dialog-footer">
-              <AriaButton className="ghost button-inline overview-location-action" isDisabled={saving} onPress={closeModal}>
-                Cancel
-              </AriaButton>
-              <AriaButton className="button-inline overview-location-save" isDisabled={saving} onPress={() => void handleSave()}>
-                {saving ? 'Updating...' : 'Update location'}
-              </AriaButton>
             </div>
           </div>
         </div>

--- a/ui/src/components/features/dashboard/OverviewLocationSwitcher.tsx
+++ b/ui/src/components/features/dashboard/OverviewLocationSwitcher.tsx
@@ -34,7 +34,7 @@ export function OverviewLocationSwitcher({
   const [saving, setSaving] = useState(false)
   const [showTooltip, setShowTooltip] = useState(false)
   const [query, setQuery] = useState(activeLocation.name)
-  const [draftLocation, setDraftLocation] = useState(activeLocation)
+  const [selectedLocation, setSelectedLocation] = useState(activeLocation)
   const [hasTypedQuery, setHasTypedQuery] = useState(false)
   const {
     results,
@@ -49,7 +49,7 @@ export function OverviewLocationSwitcher({
 
     setQuery(activeLocation.name)
     clearResults()
-    setDraftLocation(activeLocation)
+    setSelectedLocation(activeLocation)
     setHasTypedQuery(false)
 
     const timeoutId = window.setTimeout(() => {
@@ -89,8 +89,8 @@ export function OverviewLocationSwitcher({
     clearResults()
   }
 
-  function applyDraftLocation(location: OverviewLocationSelection) {
-    setDraftLocation(location)
+  function syncSelectedLocationState(location: OverviewLocationSelection) {
+    setSelectedLocation(location)
     setQuery(location.name)
     skipNextSearchFor(location.name)
     clearResults()
@@ -120,7 +120,7 @@ export function OverviewLocationSwitcher({
       return
     }
 
-    applyDraftLocation(location)
+    syncSelectedLocationState(location)
     setIsOpen(false)
     setSaving(true)
 
@@ -191,7 +191,7 @@ export function OverviewLocationSwitcher({
               <div className="overview-location-search-column">
                 <div className="overview-location-selection-card">
                   <span className="overview-location-selection-label">Selected area</span>
-                  <strong>{formatFriendlyLocation(draftLocation.name || monitoringLocation.name)}</strong>
+                  <strong>{formatFriendlyLocation(selectedLocation.name || monitoringLocation.name)}</strong>
                 </div>
 
                 <div className="overview-location-search-wrapper">
@@ -250,9 +250,9 @@ export function OverviewLocationSwitcher({
               <div className="overview-location-map-panel">
                 <Suspense fallback={<div className="overview-location-map-loading" />}>
                   <LocationPickerMap
-                    latitude={draftLocation.latitude}
-                    location={draftLocation.name}
-                    longitude={draftLocation.longitude}
+                    latitude={selectedLocation.latitude}
+                    location={selectedLocation.name}
+                    longitude={selectedLocation.longitude}
                     onSelect={({ location, latitude, longitude }) => {
                       void commitSelection({
                         name: location,

--- a/ui/src/components/layout/AppShell.tsx
+++ b/ui/src/components/layout/AppShell.tsx
@@ -123,40 +123,45 @@ function NavIcon({ itemKey, className = 'shell-mobile-nav-icon' }: Readonly<{ it
   switch (itemKey) {
     case 'overview':
       return (
-        <svg viewBox="0 0 20 20" className={className} aria-hidden="true" focusable="false">
-          <path d="M3.75 10.25 10 4.75l6.25 5.5v5a1 1 0 0 1-1 1h-2.75v-4h-5v4H4.75a1 1 0 0 1-1-1v-5Z" />
+        <svg viewBox="0 0 24 24" className={className} aria-hidden="true" focusable="false">
+          <path d="M4.75 11.5 12 5.75l7.25 5.75" />
+          <path d="M7 10.75v8h10v-8" />
+          <path d="M10 18.75v-4h4v4" />
         </svg>
       )
     case 'rules':
       return (
-        <svg viewBox="0 0 20 20" className={className} aria-hidden="true" focusable="false">
-          <path d="M10 4.5v11M4.5 10h11" />
+        <svg viewBox="0 0 24 24" className={className} aria-hidden="true" focusable="false">
+          <path d="M7.5 17.25h9l-1.35-1.9V11a3.15 3.15 0 1 0-6.3 0v4.35l-1.35 1.9Z" />
+          <path d="M10.15 18.05a1.85 1.85 0 0 0 3.7 0" />
+          <path d="M18.5 5.5v4" />
+          <path d="M16.5 7.5h4" />
         </svg>
       )
     case 'travel':
       return (
-        <svg viewBox="0 0 20 20" className={className} aria-hidden="true" focusable="false">
-          <path d="M3.75 9.25h12.5" />
-          <path d="M8 9.25 4.75 5.5" />
-          <path d="M8 9.25 4.75 13" />
-          <path d="M10.75 9.25 15.25 5.75" />
-          <path d="M10.75 9.25 15.25 12.75" />
+        <svg viewBox="0 0 24 24" className={className} aria-hidden="true" focusable="false">
+          <path d="M6 18.25h12.25" />
+          <path d="M8.75 18.25V9.5h6.5v8.75" />
+          <path d="M10 9.5V7.25A1.75 1.75 0 0 1 11.75 5.5h0.5A1.75 1.75 0 0 1 14 7.25V9.5" />
+          <path d="M8.75 12.5h6.5" />
         </svg>
       )
     case 'account':
       return (
-        <svg viewBox="0 0 20 20" className={className} aria-hidden="true" focusable="false">
-          <circle cx="10" cy="10" r="6.5" fill="none" />
-          <path d="M10 6.5a2.25 2.25 0 1 1 0 4.5 2.25 2.25 0 0 1 0-4.5Z" />
-          <path d="M12.6 7.4l1.15-1.15M7.4 12.6l-1.15 1.15M13.5 10h1.6M4.9 10H6.5M12.6 12.6l1.15 1.15M7.4 7.4 6.25 6.25" />
+        <svg viewBox="0 0 24 24" className={className} aria-hidden="true" focusable="false">
+          <circle cx="12" cy="12" r="2.6" />
+          <path d="M12 4.75v2.1M12 17.15v2.1M6.85 6.85l1.5 1.5M15.65 15.65l1.5 1.5M4.75 12h2.1M17.15 12h2.1M6.85 17.15l1.5-1.5M15.65 8.35l1.5-1.5" />
+          <circle cx="12" cy="12" r="6.75" />
         </svg>
       )
     case 'subscription':
       return (
-        <svg viewBox="0 0 20 20" className={className} aria-hidden="true" focusable="false">
-          <rect x="3.5" y="5" width="13" height="10" rx="1.5" fill="none" />
-          <path d="M3.5 8.5h13" />
-          <path d="M6.5 12h3" />
+        <svg viewBox="0 0 24 24" className={className} aria-hidden="true" focusable="false">
+          <rect x="4.5" y="6.5" width="15" height="11" rx="2.25" />
+          <path d="M4.5 10h15" />
+          <path d="M8 14h4.75" />
+          <path d="M16.5 14h0.01" />
         </svg>
       )
     case 'admin':

--- a/ui/src/components/maps/LocationPickerMap.tsx
+++ b/ui/src/components/maps/LocationPickerMap.tsx
@@ -81,14 +81,17 @@ export function LocationPickerMap({
   const handleMapClick = useCallback(
     (event: MapMouseEvent) => {
       const { lat, lng } = event.lngLat
-      const fallbackName = `Selected point (${lat.toFixed(3)}, ${lng.toFixed(3)})`
-      onSelect({ location: fallbackName, latitude: lat, longitude: lng })
-
-      void reverseGeocode(lat, lng).then((place) => {
-        if (place) {
-          onSelect({ location: place.name, latitude: place.latitude, longitude: place.longitude })
-        }
-      })
+      void reverseGeocode(lat, lng)
+        .then((place) => {
+          onSelect({
+            location: place?.name ?? 'Selected area',
+            latitude: place?.latitude ?? lat,
+            longitude: place?.longitude ?? lng,
+          })
+        })
+        .catch(() => {
+          onSelect({ location: 'Selected area', latitude: lat, longitude: lng })
+        })
     },
     [onSelect],
   )

--- a/ui/src/lib/alertConsole.ts
+++ b/ui/src/lib/alertConsole.ts
@@ -1,3 +1,6 @@
+import type { ReactNode } from 'react'
+import { CloudRain, Droplets, Thermometer, Waves, Wind } from 'lucide-react'
+import { renderAppIcon } from './appIcons'
 import { describeCriteria } from './criteria'
 import { formatFriendlyLocation, formatNumber, formatPercent, formatRelativeTime, formatTemperature, formatWind } from './formatting'
 import type { AlertCriteria, AlertEvent, WeatherCondition } from '../types'
@@ -7,7 +10,7 @@ const DAY_IN_MS = 24 * 60 * 60 * 1000
 export type AlertLifecycleState = 'triggered' | 'acknowledged' | 'resolved' | 'archived'
 
 export interface AlertMetricChip {
-  icon: string
+  icon: ReactNode
   label: string
 }
 
@@ -259,14 +262,14 @@ function buildSemanticLabel(lifecycleState: AlertLifecycleState): string {
 
 function buildMetricChips(alert: AlertEvent): AlertMetricChip[] {
   return [
-    alert.conditionTemperatureC != null ? { icon: '🌡', label: formatTemperature(alert.conditionTemperatureC, 'F') } : null,
-    alert.conditionHumidity != null ? { icon: '💧', label: formatPercent(alert.conditionHumidity) } : null,
+    alert.conditionTemperatureC != null ? { icon: renderAppIcon(Thermometer), label: formatTemperature(alert.conditionTemperatureC, 'F') } : null,
+    alert.conditionHumidity != null ? { icon: renderAppIcon(Droplets), label: formatPercent(alert.conditionHumidity) } : null,
     alert.conditionPrecipitationProbability != null
-      ? { icon: '🌧', label: formatPercent(alert.conditionPrecipitationProbability) }
+      ? { icon: renderAppIcon(CloudRain), label: formatPercent(alert.conditionPrecipitationProbability) }
       : null,
-    alert.conditionWindGust != null ? { icon: '🌬', label: formatWind(alert.conditionWindGust) } : null,
+    alert.conditionWindGust != null ? { icon: renderAppIcon(Wind), label: formatWind(alert.conditionWindGust) } : null,
     alert.conditionRiverObservedStage != null
-      ? { icon: '🌊', label: `${formatNumber(alert.conditionRiverObservedStage)} ${alert.conditionRiverStageUnit ?? 'ft'}` }
+      ? { icon: renderAppIcon(Waves), label: `${formatNumber(alert.conditionRiverObservedStage)} ${alert.conditionRiverStageUnit ?? 'ft'}` }
       : null,
   ].filter((value): value is AlertMetricChip => Boolean(value))
 }

--- a/ui/src/lib/appIcons.tsx
+++ b/ui/src/lib/appIcons.tsx
@@ -1,0 +1,11 @@
+import { createElement, type ReactNode } from 'react'
+import type { LucideIcon } from 'lucide-react'
+
+export function renderAppIcon(icon: LucideIcon, className = 'app-icon-glyph', strokeWidth = 2.1): ReactNode {
+  return createElement(icon, {
+    className,
+    'aria-hidden': true,
+    size: '1em',
+    strokeWidth,
+  })
+}

--- a/ui/src/lib/criteria.ts
+++ b/ui/src/lib/criteria.ts
@@ -1,3 +1,6 @@
+import type { ReactNode } from 'react'
+import { Cloud, CloudRain, Droplets, Search, Thermometer, Waves, Wind } from 'lucide-react'
+import { renderAppIcon } from './appIcons'
 import { formatFriendlyLocation } from './formatting'
 import type { AlertCriteria, ComparisonDirection, FloodCategory } from '../types'
 import type { CriteriaFormState, RuleType } from '../state/types'
@@ -229,23 +232,23 @@ export function resolveCriteriaVisualKind(criteria: AlertCriteria): CriteriaVisu
   return 'general'
 }
 
-export function resolveCriteriaMarkerIcon(criteria: AlertCriteria): string {
+export function resolveCriteriaMarkerIcon(criteria: AlertCriteria): ReactNode {
   switch (resolveCriteriaVisualKind(criteria)) {
     case 'temperature':
-      return '🌡'
+      return renderAppIcon(Thermometer)
     case 'rain':
-      return '🌧'
+      return renderAppIcon(CloudRain)
     case 'wind':
-      return '🌬'
+      return renderAppIcon(Wind)
     case 'humidity':
-      return '💧'
+      return renderAppIcon(Droplets)
     case 'sky':
-      return '☁'
+      return renderAppIcon(Cloud)
     case 'river':
-      return '🌊'
+      return renderAppIcon(Waves)
     case 'general':
     default:
-      return '◉'
+      return renderAppIcon(Search)
   }
 }
 

--- a/ui/src/lib/officialAlerts.ts
+++ b/ui/src/lib/officialAlerts.ts
@@ -1,9 +1,12 @@
+import type { ReactNode } from 'react'
+import { CloudFog, CloudLightning, CloudRain, CloudSnow, Cloudy, Flame, Tornado, TriangleAlert, Waves, Wind } from 'lucide-react'
+import { renderAppIcon } from './appIcons'
 import type { WeatherCondition } from '../types'
 
 export type OfficialAlertTone = 'extreme' | 'severe' | 'warning' | 'advisory' | 'notice'
 
 export interface OfficialAlertVisual {
-  icon: string
+  icon: ReactNode
   label: string
   tone: OfficialAlertTone
 }
@@ -42,38 +45,38 @@ export function resolveOfficialAlertVisual(item: Pick<WeatherCondition, 'severit
   const tone = inferTone(item)
 
   if (text.includes('tornado')) {
-    return { icon: '🌪️', label: 'Tornado', tone }
+    return { icon: renderAppIcon(Tornado), label: 'Tornado', tone }
   }
   if (text.includes('hurricane') || text.includes('tropical storm')) {
-    return { icon: '🌀', label: 'Tropical', tone }
+    return { icon: renderAppIcon(Cloudy), label: 'Tropical', tone }
   }
   if (text.includes('flood') || text.includes('flash flood')) {
-    return { icon: '🌊', label: 'Flood', tone }
+    return { icon: renderAppIcon(Waves), label: 'Flood', tone }
   }
   if (text.includes('thunderstorm') || text.includes('lightning')) {
-    return { icon: '⛈️', label: 'Storm', tone }
+    return { icon: renderAppIcon(CloudLightning), label: 'Storm', tone }
   }
   if (text.includes('wind')) {
-    return { icon: '💨', label: 'Wind', tone }
+    return { icon: renderAppIcon(Wind), label: 'Wind', tone }
   }
   if (text.includes('heat')) {
-    return { icon: '🔥', label: 'Heat', tone }
+    return { icon: renderAppIcon(Flame), label: 'Heat', tone }
   }
   if (text.includes('fire') || text.includes('smoke')) {
-    return { icon: '🔥', label: 'Fire weather', tone }
+    return { icon: renderAppIcon(Flame), label: 'Fire weather', tone }
   }
   if (text.includes('snow') || text.includes('blizzard') || text.includes('ice') || text.includes('freez')) {
-    return { icon: '❄️', label: 'Winter', tone }
+    return { icon: renderAppIcon(CloudSnow), label: 'Winter', tone }
   }
   if (text.includes('rain')) {
-    return { icon: '🌧️', label: 'Rain', tone }
+    return { icon: renderAppIcon(CloudRain), label: 'Rain', tone }
   }
   if (text.includes('air quality')) {
-    return { icon: '🌫️', label: 'Air quality', tone }
+    return { icon: renderAppIcon(CloudFog), label: 'Air quality', tone }
   }
   if (text.includes('marine') || text.includes('surf') || text.includes('coastal')) {
-    return { icon: '🌊', label: 'Marine', tone }
+    return { icon: renderAppIcon(Waves), label: 'Marine', tone }
   }
 
-  return { icon: '⚠️', label: 'Official alert', tone }
+  return { icon: renderAppIcon(TriangleAlert), label: 'Official alert', tone }
 }

--- a/ui/src/lib/overviewDashboard.ts
+++ b/ui/src/lib/overviewDashboard.ts
@@ -1,17 +1,21 @@
+import type { ReactNode } from 'react'
+import { Check, Clock3, CloudSun, Eye, MapPin, Search, Sparkles, TriangleAlert } from 'lucide-react'
+import { renderAppIcon } from './appIcons'
+import { resolveCriteriaMarkerIcon } from './criteria'
 import { deriveLifecycleState } from './alertConsole'
 import { formatFriendlyLocation, formatRelativeTimeCompact } from './formatting'
 import type { AlertCriteria, AlertEvent, WeatherCondition } from '../types'
 
 export interface OverviewRuleChip {
   id: string
-  icon: string
+  icon: ReactNode
   label: string
   href: string
 }
 
 export interface OverviewActivityItem {
   id: string
-  icon: string
+  icon: ReactNode
   title: string
   description: string
   timestamp?: string
@@ -20,7 +24,7 @@ export interface OverviewActivityItem {
 
 export interface OverviewTimelineItem {
   id: string
-  icon: string
+  icon: ReactNode
   timeLabel: string
   title: string
   description: string
@@ -98,7 +102,7 @@ function buildRecentActivity(
     .filter((item) => item.createdAt)
     .map((item) => ({
       id: `rule-${item.id}`,
-      icon: '✨',
+      icon: renderAppIcon(Sparkles),
       title: item.name?.trim() || 'New alert rule',
       description: `Started monitoring ${formatFriendlyLocation(item.location)}`,
       timestamp: item.createdAt,
@@ -111,7 +115,7 @@ function buildRecentActivity(
       ? [
           {
             id: 'forecast-watch',
-            icon: '🌤',
+            icon: renderAppIcon(CloudSun),
             title: 'Forecast watch active',
             description: currentWeather.headline,
             timestamp: currentWeather.timestamp,
@@ -140,10 +144,10 @@ function buildTimeline(criteria: AlertCriteria[], alerts: AlertEvent[], currentW
     }))
 
   const currentItem: OverviewTimelineItem[] = currentWeather
-    ? [
+      ? [
         {
           id: 'timeline-now',
-          icon: '📍',
+          icon: renderAppIcon(MapPin),
           timeLabel: 'Now',
           title: currentWeather.headline?.trim() || 'Current conditions',
           description: `${formatTemperatureLabel(currentWeather)} ${currentWeather.headline?.trim() || 'conditions in view'}`.trim(),
@@ -167,7 +171,7 @@ function buildTimeline(criteria: AlertCriteria[], alerts: AlertEvent[], currentW
       ? [
           {
             id: 'timeline-calm',
-            icon: '🕊',
+            icon: renderAppIcon(Sparkles),
             timeLabel: 'Now',
             title: 'Calm conditions',
             description: 'No alert conditions are currently active.',
@@ -181,14 +185,14 @@ function buildTimeline(criteria: AlertCriteria[], alerts: AlertEvent[], currentW
 function resolveActivityIcon(lifecycle: ReturnType<typeof deriveLifecycleState>) {
   switch (lifecycle) {
     case 'acknowledged':
-      return '👀'
+      return renderAppIcon(Eye)
     case 'resolved':
-      return '✅'
+      return renderAppIcon(Check)
     case 'archived':
-      return '🕘'
+      return renderAppIcon(Clock3)
     case 'triggered':
     default:
-      return '⚠️'
+      return renderAppIcon(TriangleAlert)
   }
 }
 
@@ -207,25 +211,17 @@ function describeActivity(lifecycle: ReturnType<typeof deriveLifecycleState>, al
 }
 
 function resolveRuleIcon(criteria: AlertCriteria) {
-  if (criteria.temperatureThreshold != null || criteria.dewPointThreshold != null) {
-    return '🌡'
-  }
-  if (criteria.rainThreshold != null) {
-    return '🌧'
-  }
-  if (criteria.maxWindSpeed != null || criteria.windGustThreshold != null) {
-    return '🌬'
-  }
-  if (criteria.humidityThreshold != null) {
-    return '💧'
-  }
-  if (criteria.skyCoverThreshold != null) {
-    return '🌫'
-  }
-  if (criteria.riverStageThreshold != null || criteria.riverFloodCategoryThreshold) {
-    return '🌊'
-  }
-  return '🔎'
+  return criteria.temperatureThreshold == null &&
+    criteria.dewPointThreshold == null &&
+    criteria.rainThreshold == null &&
+    criteria.maxWindSpeed == null &&
+    criteria.windGustThreshold == null &&
+    criteria.humidityThreshold == null &&
+    criteria.skyCoverThreshold == null &&
+    criteria.riverStageThreshold == null &&
+    !criteria.riverFloodCategoryThreshold
+    ? renderAppIcon(Search)
+    : resolveCriteriaMarkerIcon(criteria)
 }
 
 function describeOverviewRule(criteria: AlertCriteria) {

--- a/ui/src/lib/ruleDashboard.ts
+++ b/ui/src/lib/ruleDashboard.ts
@@ -1,3 +1,6 @@
+import type { ReactNode } from 'react'
+import { Search } from 'lucide-react'
+import { renderAppIcon } from './appIcons'
 import { deriveLifecycleState } from './alertConsole'
 import { describeCriteria, resolveCriteriaMarkerIcon } from './criteria'
 import { formatFriendlyLocation, formatRelativeTime } from './formatting'
@@ -14,7 +17,7 @@ export interface RuleMapGroupItem {
   triggerCondition: string
   monitoringState: RuleMonitoringState
   monitoringTone: RuleTone
-  icon: string
+  icon: ReactNode
 }
 
 export interface RuleLocationGroup {
@@ -26,7 +29,7 @@ export interface RuleLocationGroup {
   locationNames: string[]
   statusTone: RuleTone
   statusLabel: string
-  icon: string
+  icon: ReactNode
   ruleCount: number
   triggeredCount: number
   rules: RuleMapGroupItem[]
@@ -56,7 +59,7 @@ export interface RuleViewModel {
   lastAlertLabel: string
   lastAlertTime: number
   priority: number
-  icon: string
+  icon: ReactNode
   latitude?: number
   longitude?: number
   radiusKm?: number
@@ -429,7 +432,7 @@ function buildRuleLocationGroups(rules: RuleViewModel[]): RuleLocationGroup[] {
           : `${group.rules.filter((item) => item.criteria.enabled !== false).length} rule${
               group.rules.filter((item) => item.criteria.enabled !== false).length === 1 ? '' : 's'
             } monitoring`,
-      icon: primaryRule?.icon ?? '◉',
+      icon: primaryRule?.icon ?? renderAppIcon(Search),
       ruleCount: group.rules.length,
       triggeredCount,
       rules: rulesByPriority.map((item) => ({

--- a/ui/src/lib/ruleIcons.ts
+++ b/ui/src/lib/ruleIcons.ts
@@ -21,7 +21,7 @@ function renderRuleIcon(icon: LucideIcon): ReactNode {
   return renderAppIcon(icon, 'rule-icon-glyph', 2.15)
 }
 
-export function resolveRuleEmoji(icon: RuleBuilderIcon): ReactNode {
+export function resolveRuleIconNode(icon: RuleBuilderIcon): ReactNode {
   switch (icon) {
     case 'heat':
       return renderRuleIcon(Sun)
@@ -48,7 +48,7 @@ export function resolveRuleEmoji(icon: RuleBuilderIcon): ReactNode {
   }
 }
 
-export function resolveCriteriaTileEmoji(criteria: AlertCriteria): ReactNode {
+export function resolveCriteriaTileIcon(criteria: AlertCriteria): ReactNode {
   if (criteria.temperatureThreshold != null) {
     return criteria.temperatureDirection === 'BELOW' ? renderRuleIcon(Snowflake) : renderRuleIcon(Sun)
   }

--- a/ui/src/lib/ruleIcons.ts
+++ b/ui/src/lib/ruleIcons.ts
@@ -1,57 +1,77 @@
+import type { ReactNode } from 'react'
+import {
+  CloudRain,
+  CloudSun,
+  Droplets,
+  type LucideIcon,
+  Moon,
+  Snowflake,
+  Sparkles,
+  Sun,
+  TriangleAlert,
+  TrendingUp,
+  Waves,
+  Wind,
+} from 'lucide-react'
+import { renderAppIcon } from './appIcons'
 import type { RuleBuilderIcon } from './ruleBuilder'
 import type { AlertCriteria } from '../types'
 
-export function resolveRuleEmoji(icon: RuleBuilderIcon): string {
+function renderRuleIcon(icon: LucideIcon): ReactNode {
+  return renderAppIcon(icon, 'rule-icon-glyph', 2.15)
+}
+
+export function resolveRuleEmoji(icon: RuleBuilderIcon): ReactNode {
   switch (icon) {
     case 'heat':
-      return '🔥'
+      return renderRuleIcon(Sun)
     case 'jacket':
-      return '🧥'
+      return renderRuleIcon(Snowflake)
     case 'rain':
-      return '🌧️'
+      return renderRuleIcon(CloudRain)
     case 'wind':
-      return '💨'
+      return renderRuleIcon(Wind)
     case 'humidity':
-      return '💧'
+      return renderRuleIcon(Droplets)
     case 'dew':
-      return '🌙'
+      return renderRuleIcon(Moon)
     case 'river':
-      return '🏞️'
+      return renderRuleIcon(TrendingUp)
     case 'flood':
-      return '🌊'
+      return renderRuleIcon(Waves)
     case 'alert':
-      return '🚨'
+      return renderRuleIcon(TriangleAlert)
     case 'sky':
-      return '☀️'
+      return renderRuleIcon(CloudSun)
     default:
-      return '✨'
+      return renderRuleIcon(Sparkles)
   }
 }
 
-export function resolveCriteriaTileEmoji(criteria: AlertCriteria): string {
+export function resolveCriteriaTileEmoji(criteria: AlertCriteria): ReactNode {
   if (criteria.temperatureThreshold != null) {
-    return criteria.temperatureDirection === 'BELOW' ? '🧥' : '🔥'
+    return criteria.temperatureDirection === 'BELOW' ? renderRuleIcon(Snowflake) : renderRuleIcon(Sun)
   }
   if (criteria.rainThreshold != null) {
-    return '🌧️'
+    return renderRuleIcon(CloudRain)
   }
   if (criteria.maxWindSpeed != null || criteria.windGustThreshold != null) {
-    return '💨'
+    return renderRuleIcon(Wind)
   }
   if (criteria.humidityThreshold != null) {
-    return '💧'
+    return renderRuleIcon(Droplets)
   }
   if (criteria.dewPointThreshold != null) {
-    return '🌙'
+    return renderRuleIcon(Moon)
   }
   if (criteria.skyCoverThreshold != null) {
-    return '☀️'
+    return renderRuleIcon(CloudSun)
   }
   if (criteria.riverFloodCategoryThreshold) {
-    return '🌊'
+    return renderRuleIcon(Waves)
   }
   if (criteria.riverStageThreshold != null) {
-    return '🏞️'
+    return renderRuleIcon(TrendingUp)
   }
-  return '✨'
+  return renderRuleIcon(Sparkles)
 }

--- a/ui/src/lib/weatherVisuals.ts
+++ b/ui/src/lib/weatherVisuals.ts
@@ -1,3 +1,6 @@
+import type { ReactNode } from 'react'
+import { Cloud, CloudDrizzle, CloudFog, CloudLightning, CloudRain, CloudSnow, CloudSun, Sun } from 'lucide-react'
+import { renderAppIcon } from './appIcons'
 import backgroundChanceOfRainImage from '../assets/background-chance-of-rain.png'
 import backgroundCloudyImage from '../assets/background-cloudy.png'
 import backgroundFogImage from '../assets/background-fog.png'
@@ -10,11 +13,11 @@ import type { WeatherCondition } from '../types'
 
 interface WeatherVisual {
   backgroundImage: string
-  icon: string
+  icon: ReactNode
   label: string
 }
 
-function resolveFromText(value?: string): { icon: string; label: string } | null {
+function resolveFromText(value?: string): { icon: ReactNode; label: string } | null {
   if (!value) return null
   const normalized = value.toLowerCase()
 
@@ -25,22 +28,22 @@ function resolveFromText(value?: string): { icon: string; label: string } | null
     normalized.includes('sleet') ||
     normalized.includes('freezing')
   ) {
-    return { icon: '❄️', label: 'Snow' }
+    return { icon: renderAppIcon(CloudSnow), label: 'Snow' }
   }
   if (normalized.includes('thunder') || normalized.includes('tstms')) {
-    return { icon: '⛈️', label: 'Thunderstorms' }
+    return { icon: renderAppIcon(CloudLightning), label: 'Thunderstorms' }
   }
   if (normalized.includes('rain') || normalized.includes('drizzle') || normalized.includes('shower')) {
-    return { icon: '🌧️', label: 'Rainy' }
+    return { icon: renderAppIcon(CloudRain), label: 'Rainy' }
   }
   if (normalized.includes('fog') || normalized.includes('mist') || normalized.includes('haze')) {
-    return { icon: '🌫️', label: 'Foggy' }
+    return { icon: renderAppIcon(CloudFog), label: 'Foggy' }
   }
   if (normalized.includes('overcast') || normalized.includes('mostly cloudy') || normalized.includes('broken')) {
-    return { icon: '☁️', label: 'Cloudy' }
+    return { icon: renderAppIcon(Cloud), label: 'Cloudy' }
   }
   if (normalized.includes('cloud')) {
-    return { icon: '☁️', label: 'Cloudy' }
+    return { icon: renderAppIcon(Cloud), label: 'Cloudy' }
   }
   if (
     normalized.includes('partly') ||
@@ -49,36 +52,36 @@ function resolveFromText(value?: string): { icon: string; label: string } | null
     normalized.includes('mostly sunny') ||
     normalized.includes('mostly clear')
   ) {
-    return { icon: '⛅', label: 'Partly cloudy' }
+    return { icon: renderAppIcon(CloudSun), label: 'Partly cloudy' }
   }
   if (normalized.includes('fair') || normalized.includes('sunny') || normalized.includes('clear') || normalized.includes('hot')) {
-    return { icon: '☀️', label: 'Sunny' }
+    return { icon: renderAppIcon(Sun), label: 'Sunny' }
   }
 
   return null
 }
 
-function resolveFromNumeric(item: Partial<WeatherCondition>): { icon: string; label: string } {
+function resolveFromNumeric(item: Partial<WeatherCondition>): { icon: ReactNode; label: string } {
   if ((item.iceAccumulation ?? 0) > 0 || (item.snowfallAmount ?? 0) > 0) {
-    return { icon: '❄️', label: 'Snow' }
+    return { icon: renderAppIcon(CloudSnow), label: 'Snow' }
   }
   if ((item.probabilityOfThunder ?? 0) > 30) {
-    return { icon: '⛈️', label: 'Thunderstorms' }
+    return { icon: renderAppIcon(CloudLightning), label: 'Thunderstorms' }
   }
   if ((item.precipitationAmount ?? 0) > 0 || (item.precipitationProbability ?? 0) > 65) {
-    return { icon: '🌧️', label: 'Rainy' }
+    return { icon: renderAppIcon(CloudRain), label: 'Rainy' }
   }
   if ((item.precipitationProbability ?? 0) > 35) {
-    return { icon: '🌦️', label: 'Chance of rain' }
+    return { icon: renderAppIcon(CloudDrizzle), label: 'Chance of rain' }
   }
   if ((item.skyCover ?? 0) > 75) {
-    return { icon: '☁️', label: 'Cloudy' }
+    return { icon: renderAppIcon(Cloud), label: 'Cloudy' }
   }
   if ((item.skyCover ?? 0) > 40) {
-    return { icon: '⛅', label: 'Partly cloudy' }
+    return { icon: renderAppIcon(CloudSun), label: 'Partly cloudy' }
   }
 
-  return { icon: '☀️', label: 'Sunny' }
+  return { icon: renderAppIcon(Sun), label: 'Sunny' }
 }
 
 function resolveBackgroundImage(label: string): string {

--- a/ui/src/pages/AccountPage.tsx
+++ b/ui/src/pages/AccountPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, type FormEvent } from 'react'
+import { Monitor, Moon, Sun, type LucideIcon } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useThemePreference, type ThemePreference } from '../theme'
 import {
@@ -112,10 +113,10 @@ export function AccountPage() {
     setPreferenceDraft({ ...preferenceForm, enabledChannels: nextChannels, preferredChannel: fallbackPreferred })
   }
 
-  const THEME_OPTIONS: Array<{ id: ThemePreference; label: string; emoji: string; detail: string }> = [
-    { id: 'system', label: 'System', emoji: '🖥️', detail: 'Follow your device preference.' },
-    { id: 'light', label: 'Light', emoji: '☀️', detail: 'Bright daytime palette.' },
-    { id: 'dark', label: 'Dark', emoji: '🌙', detail: 'Twilight palette always.' },
+  const THEME_OPTIONS: Array<{ id: ThemePreference; label: string; icon: LucideIcon; detail: string }> = [
+    { id: 'system', label: 'System', icon: Monitor, detail: 'Follow your device preference.' },
+    { id: 'light', label: 'Light', icon: Sun, detail: 'Bright daytime palette.' },
+    { id: 'dark', label: 'Dark', icon: Moon, detail: 'Twilight palette always.' },
   ]
 
   return (
@@ -241,7 +242,7 @@ export function AccountPage() {
                     className={`settings-theme-tile${themePreference === opt.id ? ' is-active' : ''}`}
                     onClick={() => setThemePreference(opt.id)}
                   >
-                    <span className="settings-theme-emoji">{opt.emoji}</span>
+                    <span className="settings-theme-emoji" aria-hidden><opt.icon size="1em" strokeWidth={2.1} /></span>
                     <span className="settings-theme-name">{opt.label}</span>
                     <span className="settings-theme-detail">{opt.detail}</span>
                   </button>

--- a/ui/src/pages/AccountPage.tsx
+++ b/ui/src/pages/AccountPage.tsx
@@ -242,7 +242,7 @@ export function AccountPage() {
                     className={`settings-theme-tile${themePreference === opt.id ? ' is-active' : ''}`}
                     onClick={() => setThemePreference(opt.id)}
                   >
-                    <span className="settings-theme-emoji" aria-hidden><opt.icon size="1em" strokeWidth={2.1} /></span>
+                    <span className="settings-theme-icon" aria-hidden><opt.icon size="1em" strokeWidth={2.1} /></span>
                     <span className="settings-theme-name">{opt.label}</span>
                     <span className="settings-theme-detail">{opt.detail}</span>
                   </button>

--- a/ui/src/pages/OverviewPage.tsx
+++ b/ui/src/pages/OverviewPage.tsx
@@ -3,7 +3,7 @@ import { apiRequest, toErrorMessage } from '../api'
 import { OverviewLocationSwitcher, type OverviewLocationSelection } from '../components/features/dashboard/OverviewLocationSwitcher'
 import { formatDate, formatFriendlyLocation, formatPercentOrNA, formatRelativeTime, formatRelativeTimeCompact, formatTemperature } from '../lib/formatting'
 import { resolveOfficialAlertVisual } from '../lib/officialAlerts'
-import { resolveCriteriaTileEmoji } from '../lib/ruleIcons'
+import { resolveCriteriaTileIcon } from '../lib/ruleIcons'
 import { resolveWeatherVisual } from '../lib/weatherVisuals'
 import { DEFAULT_LAT, DEFAULT_LON } from '../state/types'
 import { useActionState, useAsyncState, useDataState, useNoticeState, useSessionState } from '../state/useAppState'
@@ -485,7 +485,7 @@ export function OverviewPage() {
                 const visual = resolveOfficialAlertVisual(item)
                 const title = criteriaItem?.name?.trim() || item.eventType?.trim() || item.headline?.trim() || 'Alert'
                 const area = formatFriendlyLocation(item.location || 'Selected area')
-                const icon = criteriaItem ? resolveCriteriaTileEmoji(criteriaItem) : visual.icon
+                const icon = criteriaItem ? resolveCriteriaTileIcon(criteriaItem) : visual.icon
 
                 return (
                   <button

--- a/ui/src/pages/OverviewPage.tsx
+++ b/ui/src/pages/OverviewPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { apiRequest, toErrorMessage } from '../api'
 import { OverviewLocationSwitcher, type OverviewLocationSelection } from '../components/features/dashboard/OverviewLocationSwitcher'
 import { formatDate, formatFriendlyLocation, formatPercentOrNA, formatRelativeTime, formatRelativeTimeCompact, formatTemperature } from '../lib/formatting'
@@ -15,7 +15,7 @@ interface MinimalForecastItem {
   label: string
   temperatureLabel: string
   precipitationLabel: string
-  icon: string
+  icon: ReactNode
 }
 
 interface CustomOverviewView {
@@ -30,7 +30,7 @@ function resolveDisplayTime(item: WeatherCondition): string | undefined {
   return item.onset ?? item.timestamp
 }
 
-function resolveWeatherIcon(item: Partial<WeatherCondition>): string {
+function resolveWeatherIcon(item: Partial<WeatherCondition>): ReactNode {
   return resolveWeatherVisual(item).icon
 }
 

--- a/ui/src/pages/RulesPage.tsx
+++ b/ui/src/pages/RulesPage.tsx
@@ -20,18 +20,6 @@ import type { AlertCriteria } from '../types'
 
 type ModalStatus = 'idle' | 'saving' | 'success' | 'error'
 
-const TILE_SUBTITLES: Record<string, string> = {
-  'chilly-weather': 'Temperature below 60°F',
-  'hot-day-ahead': 'Temperature above 90°F',
-  'rain-coming': 'Rain chance above 75%',
-  'windy-outside': 'Wind speed above 30 km/h',
-  'very-humid': 'Humidity above 80%',
-  'warm-muggy-night': 'Dew point above 68°F',
-  'river-rising': 'River stage above 8 ft',
-  'river-problem': 'Flood watch level reached',
-  'minor-flooding': 'Minor flooding detected',
-}
-
 const FLOOD_CATEGORY_LABELS: Record<string, string> = {
   ACTION: 'Watch level',
   MINOR: 'Minor flooding',
@@ -399,16 +387,13 @@ export function RulesPage() {
             return (
               <button
                 key={preset.id}
-                className={`rules-tile${isEnabled ? ' is-enabled' : ''}`}
+                className={`rules-tile rules-preset-tile${isEnabled ? ' is-enabled' : ''}`}
                 type="button"
                 aria-pressed={isEnabled}
                 onClick={() => toggle(preset)}
               >
                 <span className="rules-tile-icon">{resolveRuleEmoji(preset.icon)}</span>
                 <span className="rules-tile-name">{preset.title}</span>
-                <span className="rules-tile-desc">
-                  {TILE_SUBTITLES[preset.id] ?? preset.description}
-                </span>
               </button>
             )
           })}

--- a/ui/src/pages/RulesPage.tsx
+++ b/ui/src/pages/RulesPage.tsx
@@ -2,7 +2,7 @@ import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState, type
 import { apiRequest } from '../api'
 import { buildCriteriaPayload, defaultThreshold, describeCriteria } from '../lib/criteria'
 import { formatFriendlyLocation } from '../lib/formatting'
-import { resolveCriteriaTileEmoji, resolveRuleEmoji } from '../lib/ruleIcons'
+import { resolveCriteriaTileIcon, resolveRuleIconNode } from '../lib/ruleIcons'
 import {
   QUICK_START_PRESETS,
   SIMPLE_SITUATIONS,
@@ -392,7 +392,7 @@ export function RulesPage() {
                 aria-pressed={isEnabled}
                 onClick={() => toggle(preset)}
               >
-                <span className="rules-tile-icon">{resolveRuleEmoji(preset.icon)}</span>
+                <span className="rules-tile-icon">{resolveRuleIconNode(preset.icon)}</span>
                 <span className="rules-tile-name">{preset.title}</span>
               </button>
             )
@@ -414,7 +414,7 @@ export function RulesPage() {
                   aria-label={`Edit ${item.name?.trim() || 'custom alert'}`}
                 >
                   <div className="rules-custom-rule-top">
-                    <span className="rules-tile-icon">{resolveCriteriaTileEmoji(item)}</span>
+                    <span className="rules-tile-icon">{resolveCriteriaTileIcon(item)}</span>
                   </div>
                   <span className="rules-tile-name">{item.name?.trim() || 'Custom alert'}</span>
                   <span className="rules-custom-rule-location">{formatFriendlyLocation(item.location)}</span>
@@ -438,7 +438,7 @@ export function RulesPage() {
               type="button"
               onClick={() => openCategory(situation)}
             >
-              <span className="rules-tile-icon">{resolveRuleEmoji(situation.icon)}</span>
+              <span className="rules-tile-icon">{resolveRuleIconNode(situation.icon)}</span>
               <span className="rules-tile-name">{situation.title}</span>
             </button>
           ))}
@@ -454,7 +454,7 @@ export function RulesPage() {
         >
           <div className={`rules-modal rules-modal--builder${modalStatus === 'success' ? ' is-success' : ''}${modalStatus === 'error' ? ' is-error' : ''}`} role="dialog" aria-label={`${editingCriteria ? 'Edit' : 'Create'} ${modalSituation.title} alert`}>
             <div className="rules-modal-header">
-              <span className="rules-modal-icon">{resolveRuleEmoji(modalSituation.icon)}</span>
+              <span className="rules-modal-icon">{resolveRuleIconNode(modalSituation.icon)}</span>
               <h2 className="rules-modal-title">{editingCriteria ? `Edit ${modalSituation.title}` : modalSituation.title}</h2>
               <button type="button" className="rules-modal-close" aria-label="Close" onClick={closeModal}>✕</button>
             </div>

--- a/ui/src/pages/SubscriptionPage.tsx
+++ b/ui/src/pages/SubscriptionPage.tsx
@@ -154,7 +154,7 @@ export function SubscriptionPage() {
                   onClick={() => isCurrent ? void handleOpenBillingPortal() : setPendingPlan(plan.id)}
                 >
                   <div className="sub-plan-top">
-                    <span className="sub-plan-emoji" aria-hidden><plan.icon size="1em" strokeWidth={2.1} /></span>
+                    <span className="sub-plan-icon" aria-hidden><plan.icon size="1em" strokeWidth={2.1} /></span>
                     <span className="sub-plan-price">{plan.monthlyPrice}<small>/mo</small></span>
                   </div>
                   <h3 className="sub-plan-name">{plan.name}</h3>
@@ -199,7 +199,7 @@ export function SubscriptionPage() {
 
             <div className="sub-dialog-body">
               <div className="sub-dialog-plan-card">
-                <span className="sub-plan-emoji" aria-hidden><pendingDetails.icon size="1em" strokeWidth={2.1} /></span>
+                <span className="sub-plan-icon" aria-hidden><pendingDetails.icon size="1em" strokeWidth={2.1} /></span>
                 <div>
                   <strong>{pendingDetails.name}</strong>
                   <span className="sub-dialog-price">{pendingDetails.monthlyPrice}/mo</span>

--- a/ui/src/pages/SubscriptionPage.tsx
+++ b/ui/src/pages/SubscriptionPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
+import { House, MapPinned, Radar, type LucideIcon } from 'lucide-react'
 import type { BillingPlan } from '../types'
 import {
   useActionState,
@@ -11,7 +12,7 @@ import {
 const PLAN_DETAILS: Array<{
   id: BillingPlan
   name: string
-  emoji: string
+  icon: LucideIcon
   monthlyPrice: string
   activeAlertsLabel: string
   travelPlansLabel: string
@@ -21,7 +22,7 @@ const PLAN_DETAILS: Array<{
   {
     id: 'FREE',
     name: 'Home',
-    emoji: '☁️',
+    icon: House,
     monthlyPrice: '$0',
     activeAlertsLabel: '1 active alert',
     travelPlansLabel: 'No travel plans',
@@ -31,7 +32,7 @@ const PLAN_DETAILS: Array<{
   {
     id: 'PLUS',
     name: 'Neighborhood',
-    emoji: '✨',
+    icon: MapPinned,
     monthlyPrice: '$6',
     activeAlertsLabel: '10 active alerts',
     travelPlansLabel: '3 travel plans',
@@ -41,7 +42,7 @@ const PLAN_DETAILS: Array<{
   {
     id: 'PRO',
     name: 'Everywhere',
-    emoji: '🛰️',
+    icon: Radar,
     monthlyPrice: '$9',
     activeAlertsLabel: '50 active alerts',
     travelPlansLabel: '15 travel plans',
@@ -153,7 +154,7 @@ export function SubscriptionPage() {
                   onClick={() => isCurrent ? void handleOpenBillingPortal() : setPendingPlan(plan.id)}
                 >
                   <div className="sub-plan-top">
-                    <span className="sub-plan-emoji">{plan.emoji}</span>
+                    <span className="sub-plan-emoji" aria-hidden><plan.icon size="1em" strokeWidth={2.1} /></span>
                     <span className="sub-plan-price">{plan.monthlyPrice}<small>/mo</small></span>
                   </div>
                   <h3 className="sub-plan-name">{plan.name}</h3>
@@ -198,7 +199,7 @@ export function SubscriptionPage() {
 
             <div className="sub-dialog-body">
               <div className="sub-dialog-plan-card">
-                <span className="sub-plan-emoji">{pendingDetails.emoji}</span>
+                <span className="sub-plan-emoji" aria-hidden><pendingDetails.icon size="1em" strokeWidth={2.1} /></span>
                 <div>
                   <strong>{pendingDetails.name}</strong>
                   <span className="sub-dialog-price">{pendingDetails.monthlyPrice}/mo</span>

--- a/ui/src/pages/TravelPlansPage.tsx
+++ b/ui/src/pages/TravelPlansPage.tsx
@@ -1,4 +1,6 @@
-import { Suspense, lazy, useEffect, useRef, useState } from 'react'
+import { Suspense, lazy, useEffect, useRef, useState, type ReactNode } from 'react'
+import { CalendarDays, Check, MapPinned, Plane } from 'lucide-react'
+import { renderAppIcon } from '../lib/appIcons'
 import { usePlaceSearch } from '../hooks/usePlaceSearch'
 import { DEFAULT_LAT, DEFAULT_LON } from '../state/types'
 import { useActionState, useDataState } from '../state/useAppState'
@@ -28,10 +30,10 @@ function tripStatus(plan: TravelPlan): 'active' | 'upcoming' | 'past' {
   return 'active'
 }
 
-function statusEmoji(s: 'active' | 'upcoming' | 'past') {
-  if (s === 'active') return '🟢'
-  if (s === 'upcoming') return '📅'
-  return '✓'
+function statusIcon(s: 'active' | 'upcoming' | 'past'): ReactNode {
+  if (s === 'active') return renderAppIcon(Plane)
+  if (s === 'upcoming') return renderAppIcon(CalendarDays)
+  return renderAppIcon(Check)
 }
 
 function formatRange(start?: string, end?: string) {
@@ -196,7 +198,7 @@ export function TravelPlansPage() {
         {empty ? (
           /* ── empty state ── */
           <div className="travel-empty">
-            <span className="travel-empty-icon">✈️</span>
+            <span className="travel-empty-icon">{renderAppIcon(Plane)}</span>
             <p className="travel-empty-label">No trips yet</p>
             <button className="travel-add-btn" type="button" onClick={openCreate}>
               + Plan a trip
@@ -228,7 +230,7 @@ export function TravelPlansPage() {
                       </div>
                     ) : (
                       <div className="travel-tile-map-placeholder">
-                        <span>🗺️</span>
+                        <span>{renderAppIcon(MapPinned)}</span>
                       </div>
                     )}
                     <div className="travel-tile-body">
@@ -236,7 +238,8 @@ export function TravelPlansPage() {
                       <p className="travel-tile-name">{plan.name}</p>
                       <p className="travel-tile-dates">{formatRange(plan.startDate, plan.endDate)}</p>
                       <span className="travel-tile-badge">
-                        {statusEmoji(status)} {daysLabel(plan)}
+                        <span className="travel-tile-badge-icon" aria-hidden>{statusIcon(status)}</span>
+                        <span>{daysLabel(plan)}</span>
                       </span>
                     </div>
                   </button>
@@ -260,7 +263,7 @@ export function TravelPlansPage() {
           <div className={`travel-modal travel-modal--${mode}${modalStatus === 'success' ? ' is-success' : ''}${modalStatus === 'error' ? ' is-error' : ''}`}>
             {/* header */}
             <div className="travel-modal-header">
-              <span className="travel-modal-icon">{mode === 'create' ? '✈️' : '🗺️'}</span>
+              <span className="travel-modal-icon">{mode === 'create' ? renderAppIcon(Plane) : renderAppIcon(MapPinned)}</span>
               <h2 className="travel-modal-title">
                 {mode === 'create' ? 'Plan a trip' : mode === 'edit' ? 'Edit trip' : (selected?.name ?? 'Trip')}
               </h2>
@@ -285,7 +288,8 @@ export function TravelPlansPage() {
                 <p className="travel-detail-destination">{selected.destination}</p>
                 <p className="travel-detail-dates">{formatRange(selected.startDate, selected.endDate)}</p>
                 <span className="travel-detail-badge">
-                  {statusEmoji(tripStatus(selected))} {daysLabel(selected)}
+                  <span className="travel-tile-badge-icon" aria-hidden>{statusIcon(tripStatus(selected))}</span>
+                  <span>{daysLabel(selected)}</span>
                 </span>
                 {selected.notes ? <p className="travel-detail-notes">{selected.notes}</p> : null}
 

--- a/ui/src/styles/account.css
+++ b/ui/src/styles/account.css
@@ -357,7 +357,7 @@
   filter: hue-rotate(-22deg) saturate(1.18);
 }
 
-.settings-theme-emoji {
+.settings-theme-icon {
   display: grid;
   place-items: center;
   font-size: 1.4rem;

--- a/ui/src/styles/account.css
+++ b/ui/src/styles/account.css
@@ -325,8 +325,16 @@
   gap: 0.3rem;
   padding: 0.85rem 0.5rem;
   border-radius: 0.9rem;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.34);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.03)),
+    rgba(97, 124, 157, 0.72);
+  box-shadow:
+    0 16px 30px rgba(31, 58, 112, 0.26),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(10px) saturate(1.08);
+  -webkit-backdrop-filter: blur(10px) saturate(1.08);
   color: rgba(255, 255, 255, 0.65);
   cursor: pointer;
   text-align: center;
@@ -334,18 +342,24 @@
 }
 
 .settings-theme-tile:hover {
-  background: rgba(255, 255, 255, 0.1);
+  box-shadow:
+    0 18px 34px rgba(31, 58, 112, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.24),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.08);
   transform: translateY(-1px);
 }
 
 .settings-theme-tile.is-active {
-  border-color: rgba(120, 200, 255, 0.4);
-  background: rgba(120, 200, 255, 0.12);
+  border-color: var(--frost-tile-active-border);
+  background: var(--frost-tile-active-background);
   color: #fff;
-  box-shadow: 0 0 0 1px rgba(120, 200, 255, 0.1), 0 6px 18px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--frost-tile-active-shadow);
+  filter: hue-rotate(-22deg) saturate(1.18);
 }
 
 .settings-theme-emoji {
+  display: grid;
+  place-items: center;
   font-size: 1.4rem;
 }
 

--- a/ui/src/styles/common.css
+++ b/ui/src/styles/common.css
@@ -19,6 +19,19 @@ html:has(.app-shell.is-immersive-route) #root {
 .app-shell {
   --bottom-nav-content-clearance: 0px;
   --bottom-nav-floating-clearance: 0px;
+  --frost-tile-border: var(--frost-surface-border);
+  --frost-tile-background: var(--frost-surface-bg);
+  --frost-tile-shadow: var(--frost-surface-shadow);
+  --frost-tile-hover-shadow: var(--frost-surface-shadow-hover);
+  --frost-tile-active-border: rgba(117, 244, 255, 0.52);
+  --frost-tile-active-background:
+    linear-gradient(180deg, rgba(196, 255, 250, 0.34), rgba(126, 213, 255, 0.14)),
+    rgba(78, 164, 255, 0.18);
+  --frost-tile-active-shadow:
+    0 0 0 1px rgba(120, 232, 255, 0.16),
+    0 12px 26px rgba(21, 87, 148, 0.24),
+    inset 0 1px 0 rgba(255, 255, 255, 0.62),
+    inset 0 -1px 0 rgba(130, 211, 255, 0.22);
   position: relative;
   min-height: 100vh;
   padding: 2rem;
@@ -128,8 +141,8 @@ html:has(.app-shell.is-immersive-route) #root {
   border: 0;
   border-radius: 999px;
   background: transparent;
-  color: rgba(255, 255, 255, 0.82);
-  transition: color 120ms ease, transform 120ms ease;
+  color: rgba(255, 255, 255, 0.9);
+  transition: color 120ms ease, transform 120ms ease, filter 180ms ease;
 }
 
 .app-shell.has-bottom-nav .shell-mobile-nav-link:hover {
@@ -141,7 +154,7 @@ html:has(.app-shell.is-immersive-route) #root {
 .app-shell.has-bottom-nav .shell-mobile-nav-link.active {
   background: transparent;
   border-color: transparent;
-  color: #ffffff;
+  color: #bffcff;
   transform: translateY(-1px);
 }
 
@@ -152,32 +165,26 @@ html:has(.app-shell.is-immersive-route) #root {
   width: 2.9rem;
   height: 2.9rem;
   border-radius: 1rem;
-  border: 1px solid transparent;
-  background: transparent;
-  box-shadow: none;
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
+  border: 1px solid var(--frost-tile-border);
+  background: var(--frost-tile-background);
+  box-shadow: var(--frost-tile-shadow);
+  backdrop-filter: blur(10px) saturate(1.08);
+  -webkit-backdrop-filter: blur(10px) saturate(1.08);
   transition:
     border-color 180ms ease,
     background 180ms ease,
     box-shadow 180ms ease,
     backdrop-filter 180ms ease,
     -webkit-backdrop-filter 180ms ease,
+    filter 180ms ease,
     transform 120ms ease;
 }
 
 .app-shell.has-bottom-nav .shell-mobile-nav-link.active .shell-mobile-nav-icon-frame {
-  border-color: rgba(120, 200, 255, 0.4);
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0.1)),
-    rgba(130, 170, 224, 0.12);
-  box-shadow:
-    0 0 0 1px rgba(100, 185, 255, 0.12),
-    0 10px 22px rgba(31, 58, 112, 0.14),
-    inset 0 1px 0 rgba(255, 255, 255, 0.55),
-    inset 0 -1px 0 rgba(255, 255, 255, 0.15);
-  backdrop-filter: blur(10px) saturate(1.08);
-  -webkit-backdrop-filter: blur(10px) saturate(1.08);
+  border-color: var(--frost-tile-active-border);
+  background: var(--frost-tile-active-background);
+  box-shadow: var(--frost-tile-active-shadow);
+  filter: hue-rotate(-22deg) saturate(1.22);
 }
 
 .app-shell.has-bottom-nav .shell-mobile-nav-icon {
@@ -185,7 +192,9 @@ html:has(.app-shell.is-immersive-route) #root {
   height: 1.72rem;
   stroke: currentColor;
   stroke-width: 2.4;
-  fill: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
   filter: drop-shadow(0 8px 18px rgba(27, 45, 85, 0.35));
 }
 
@@ -286,7 +295,8 @@ html:has(.app-shell.is-immersive-route) #root {
   box-shadow:
     var(--panel-shadow),
     inset 0 1px 0 rgba(255, 255, 255, 0.32);
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(10px) saturate(1.08);
+  -webkit-backdrop-filter: blur(10px) saturate(1.08);
 }
 
 .panel h2 {
@@ -2376,4 +2386,9 @@ button:disabled {
   background: rgba(var(--accent-rgb), 0.12);
   color: var(--accent-700);
   font-weight: 700;
+}
+.app-icon-glyph,
+.rule-icon-glyph {
+  display: block;
+  flex-shrink: 0;
 }

--- a/ui/src/styles/dashboard.css
+++ b/ui/src/styles/dashboard.css
@@ -417,6 +417,8 @@
 .monitoring-map-marker-icon {
   font-size: 1rem;
   line-height: 1;
+  display: grid;
+  place-items: center;
 }
 
 .monitoring-map-marker-count {
@@ -722,6 +724,12 @@
   white-space: nowrap;
 }
 
+.metric-pill > span[aria-hidden] {
+  display: grid;
+  place-items: center;
+  font-size: 0.92rem;
+}
+
 .alert-row-actions {
   display: flex;
   align-items: center;
@@ -974,6 +982,8 @@
 }
 
 .overview-minimal-condition-icon {
+  display: grid;
+  place-items: center;
   font-size: 1.5rem;
   line-height: 1;
 }
@@ -1014,15 +1024,16 @@
   align-items: center;
   padding: 0.95rem 1rem;
   border-radius: 1.35rem;
-  border: 1px solid rgba(255, 255, 255, 0.22);
+  border: 1px solid rgba(255, 255, 255, 0.34);
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.24), rgba(255, 255, 255, 0.1)),
-    rgba(13, 27, 56, 0.2);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.03)),
+    rgba(97, 124, 157, 0.72);
   box-shadow:
-    0 18px 34px rgba(18, 38, 73, 0.18),
-    inset 0 1px 0 rgba(255, 255, 255, 0.32);
-  -webkit-backdrop-filter: blur(16px) saturate(1.12);
-  backdrop-filter: blur(16px) saturate(1.12);
+    0 16px 30px rgba(31, 58, 112, 0.26),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.06);
+  -webkit-backdrop-filter: blur(10px) saturate(1.08);
+  backdrop-filter: blur(10px) saturate(1.08);
   text-align: left;
   transform-origin: center top;
   overflow: visible;
@@ -1077,36 +1088,36 @@
 
 .overview-official-alert-card.is-extreme {
   background:
-    linear-gradient(180deg, rgba(255, 232, 232, 0.38), rgba(255, 196, 196, 0.16)),
-    rgba(117, 12, 36, 0.26);
+    linear-gradient(180deg, rgba(255, 237, 240, 0.1), rgba(255, 171, 185, 0.03)),
+    rgba(132, 8, 33, 0.72);
   border-color: rgba(255, 184, 184, 0.48);
 }
 
 .overview-official-alert-card.is-severe {
   background:
-    linear-gradient(180deg, rgba(255, 240, 231, 0.34), rgba(255, 197, 156, 0.16)),
-    rgba(135, 57, 13, 0.24);
+    linear-gradient(180deg, rgba(255, 241, 228, 0.1), rgba(255, 200, 153, 0.03)),
+    rgba(135, 57, 13, 0.7);
   border-color: rgba(255, 202, 152, 0.42);
 }
 
 .overview-official-alert-card.is-warning {
   background:
-    linear-gradient(180deg, rgba(255, 247, 214, 0.34), rgba(255, 231, 153, 0.14)),
-    rgba(121, 90, 8, 0.22);
+    linear-gradient(180deg, rgba(255, 247, 214, 0.1), rgba(255, 231, 153, 0.03)),
+    rgba(121, 90, 8, 0.66);
   border-color: rgba(255, 226, 143, 0.42);
 }
 
 .overview-official-alert-card.is-advisory {
   background:
-    linear-gradient(180deg, rgba(231, 245, 255, 0.32), rgba(166, 211, 255, 0.14)),
-    rgba(14, 67, 121, 0.22);
+    linear-gradient(180deg, rgba(231, 245, 255, 0.1), rgba(166, 211, 255, 0.03)),
+    rgba(14, 67, 121, 0.68);
   border-color: rgba(176, 219, 255, 0.38);
 }
 
 .overview-official-alert-card.is-notice {
   background:
-    linear-gradient(180deg, rgba(235, 247, 255, 0.3), rgba(203, 227, 255, 0.14)),
-    rgba(27, 73, 112, 0.2);
+    linear-gradient(180deg, rgba(235, 247, 255, 0.09), rgba(203, 227, 255, 0.03)),
+    rgba(27, 73, 112, 0.64);
   border-color: rgba(199, 225, 255, 0.34);
 }
 
@@ -1156,16 +1167,19 @@
   place-items: center;
   width: 4.6rem;
   height: 4.6rem;
-  border-radius: 1.2rem;
-  background: rgba(255, 255, 255, 0.18);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.26),
-    0 10px 18px rgba(18, 38, 73, 0.18);
 }
 
 .overview-official-alert-icon span {
+  display: grid;
+  place-items: center;
   font-size: 2.25rem;
   line-height: 1;
+}
+
+.overview-official-alert-icon span .rule-icon-glyph,
+.overview-official-alert-icon span .app-icon-glyph {
+  width: 2rem;
+  height: 2rem;
 }
 
 .overview-official-alert-body {
@@ -1195,7 +1209,13 @@
   padding: 0;
   border: 0;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.03)),
+    rgba(97, 124, 157, 0.54);
+  box-shadow:
+    0 10px 20px rgba(31, 58, 112, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.18);
   color: rgba(255, 255, 255, 0.94);
   font: inherit;
   font-size: 1rem;
@@ -1206,7 +1226,9 @@
 }
 
 .overview-official-alert-more:hover {
-  background: rgba(255, 255, 255, 0.22);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.04)),
+    rgba(106, 134, 170, 0.62);
   transform: translateY(-1px);
 }
 
@@ -1459,14 +1481,14 @@ button.overview-official-alert-card:disabled {
   margin-top: auto;
   padding: 0.8rem;
   border-radius: 1.4rem;
-  border: 1px solid rgba(255, 255, 255, 0.48);
+  border: 1px solid rgba(255, 255, 255, 0.34);
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.14)),
-    rgba(130, 170, 224, 0.12);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.03)),
+    rgba(97, 124, 157, 0.74);
   box-shadow:
-    0 14px 28px rgba(31, 58, 112, 0.16),
-    inset 0 1px 0 rgba(255, 255, 255, 0.6),
-    inset 0 -1px 0 rgba(255, 255, 255, 0.18);
+    0 16px 30px rgba(31, 58, 112, 0.26),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.06);
   -webkit-backdrop-filter: blur(10px) saturate(1.08);
   backdrop-filter: blur(10px) saturate(1.08);
 }
@@ -1595,6 +1617,8 @@ button.overview-official-alert-card:disabled {
 }
 
 .overview-minimal-forecast-icon {
+  display: grid;
+  place-items: center;
   font-size: 1.45rem;
   line-height: 1;
 }
@@ -1967,7 +1991,8 @@ button.overview-official-alert-card:disabled {
 }
 
 .overview-location-dialog--picker {
-  min-height: min(44rem, calc(100dvh - var(--bottom-nav-content-clearance) - 1.8rem));
+  width: min(100%, 44rem);
+  min-height: auto;
   max-height: calc(100dvh - var(--bottom-nav-content-clearance) - 1.8rem);
   overflow-y: auto;
 }
@@ -1975,70 +2000,54 @@ button.overview-official-alert-card:disabled {
 .overview-location-dialog-header {
   display: flex;
   justify-content: space-between;
-  gap: 1rem;
-  align-items: flex-start;
+  gap: 0.9rem;
+  align-items: center;
 }
 
 .overview-location-dialog-header h2 {
-  margin: 0.12rem 0 0;
+  margin: 0;
   font-family: var(--font-heading);
   color: rgba(255, 255, 255, 0.96);
 }
 
-.overview-location-dialog-copy {
-  margin: 0.4rem 0 0;
-  max-width: 42rem;
-  color: rgba(255, 255, 255, 0.72);
-}
-
 .overview-location-picker-grid {
   display: grid;
-  gap: 1rem;
-  grid-template-columns: minmax(20rem, 0.88fr) minmax(0, 1.42fr);
+  gap: 0.95rem;
+  grid-template-columns: 1fr;
   align-items: start;
   flex: 1;
 }
 
 .overview-location-search-column {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.8rem;
 }
 
 .overview-location-search-wrapper {
   position: relative;
 }
 
-.overview-location-search-field {
-  display: grid;
-  gap: 0.24rem;
-  font-size: 0.88rem;
-  color: rgba(255, 255, 255, 0.72);
-}
-
 .overview-location-search-input {
   color: rgba(255, 255, 255, 0.96);
+  min-height: 3.4rem;
+  padding-inline: 1rem;
   background: rgba(255, 255, 255, 0.12);
-  border-color: rgba(255, 255, 255, 0.16);
-}
-
-.overview-location-search-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem;
-  justify-content: flex-start;
-}
-
-.overview-location-action {
-  min-width: 0;
+  border-color: rgba(255, 255, 255, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 .overview-location-close {
-  min-width: 0;
-}
-
-.overview-location-status {
-  margin: -0.1rem 0 0;
-  color: rgba(255, 255, 255, 0.72);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.94);
+  font-size: 1rem;
+  cursor: pointer;
 }
 
 .overview-location-results {
@@ -2048,20 +2057,13 @@ button.overview-official-alert-card:disabled {
 
 .overview-location-selection-card {
   display: grid;
-  gap: 0.18rem;
-  padding: 0.85rem 0.9rem;
-  border-radius: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  background: rgba(255, 255, 255, 0.1);
+  gap: 0.24rem;
 }
 
 .overview-location-selection-card strong {
   color: rgba(255, 255, 255, 0.96);
-  font-size: 1rem;
-}
-
-.overview-location-selection-card span:last-child {
-  color: rgba(255, 255, 255, 0.72);
+  font-size: clamp(1.02rem, 2.3vw, 1.14rem);
+  line-height: 1.2;
 }
 
 .overview-location-selection-label {
@@ -2076,13 +2078,9 @@ button.overview-official-alert-card:disabled {
   min-height: 100%;
 }
 
-.overview-location-map-panel .location-picker-stack {
-  gap: 0.65rem;
-}
-
 .overview-location-map-panel .location-map-shell,
 .overview-location-map-loading {
-  min-height: min(34rem, calc(100dvh - 12rem));
+  min-height: min(28rem, calc(100dvh - 16rem));
   border-radius: 1.1rem;
   border-color: rgba(255, 255, 255, 0.14);
   background: rgba(255, 255, 255, 0.09);
@@ -2104,26 +2102,12 @@ button.overview-official-alert-card:disabled {
   animation: overviewGlassFloat 2.8s ease-in-out infinite;
 }
 
+.overview-location-map-panel .location-picker-stack {
+  gap: 0;
+}
+
 .overview-location-map-panel .location-selected-label {
-  color: rgba(255, 255, 255, 0.7);
-}
-
-.overview-location-dialog-footer {
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.6rem;
-}
-
-.overview-location-save {
-  min-width: 8.5rem;
-  justify-content: center;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.22);
-  background: rgba(255, 255, 255, 0.18);
-  color: rgba(255, 255, 255, 0.98);
-  box-shadow:
-    0 12px 24px rgba(10, 20, 50, 0.18),
-    inset 0 1px 0 rgba(255, 255, 255, 0.24);
+  display: none;
 }
 
 .overview-grid {
@@ -2265,6 +2249,11 @@ button.overview-official-alert-card:disabled {
   justify-content: center;
   border-radius: 999px;
   background: rgba(var(--accent-bright-rgb), 0.12);
+}
+
+.overview-activity-icon .app-icon-glyph,
+.overview-timeline-marker .app-icon-glyph {
+  font-size: 1rem;
 }
 
 .overview-activity-copy {
@@ -2638,6 +2627,8 @@ button.overview-official-alert-card:disabled {
 }
 
 .daily-forecast-day-icon {
+  display: grid;
+  place-items: center;
   font-size: 1.45rem;
   line-height: 1;
   margin: 0.1rem 0;
@@ -2650,6 +2641,9 @@ button.overview-official-alert-card:disabled {
 }
 
 .daily-forecast-day-rain {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.22rem;
   font-size: 0.7rem;
   color: var(--text-muted);
 }
@@ -2707,6 +2701,8 @@ button.overview-official-alert-card:disabled {
 }
 
 .hourly-forecast-icon {
+  display: grid;
+  place-items: center;
   font-size: 1.1rem;
   line-height: 1;
 }
@@ -2718,9 +2714,18 @@ button.overview-official-alert-card:disabled {
 }
 
 .hourly-forecast-rain {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.22rem;
   font-size: 0.68rem;
   color: var(--text-muted);
   white-space: nowrap;
+}
+
+.forecast-precip-icon {
+  display: grid;
+  place-items: center;
+  font-size: 0.82rem;
 }
 
 /* ── NWS Text Products Panel ────────────────────────────────────────────── */
@@ -2874,6 +2879,8 @@ button.overview-official-alert-card:disabled {
 .nws-product-icon {
   flex-shrink: 0;
   font-size: 1.05rem;
+  display: grid;
+  place-items: center;
 }
 
 .nws-product-summary-main {

--- a/ui/src/styles/responsive.css
+++ b/ui/src/styles/responsive.css
@@ -193,8 +193,8 @@
     border: 0;
     border-radius: 999px;
     background: transparent;
-    color: rgba(255, 255, 255, 0.82);
-    transition: color 120ms ease, transform 120ms ease;
+    color: rgba(255, 255, 255, 0.9);
+    transition: color 120ms ease, transform 120ms ease, filter 180ms ease;
   }
 
   .shell-mobile-nav-link:hover {
@@ -206,7 +206,7 @@
   .shell-mobile-nav-link.active {
     background: transparent;
     border-color: transparent;
-    color: #ffffff;
+    color: #bffcff;
     transform: translateY(-1px);
   }
 
@@ -217,32 +217,37 @@
     width: 2.9rem;
     height: 2.9rem;
     border-radius: 1rem;
-    border: 1px solid transparent;
-    background: transparent;
-    box-shadow: none;
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.24), rgba(255, 255, 255, 0.08)),
+      rgba(130, 170, 224, 0.1);
+    box-shadow:
+      0 8px 22px rgba(31, 58, 112, 0.16),
+      inset 0 1px 0 rgba(255, 255, 255, 0.46),
+      inset 0 -1px 0 rgba(255, 255, 255, 0.12);
+    backdrop-filter: blur(10px) saturate(1.08);
+    -webkit-backdrop-filter: blur(10px) saturate(1.08);
     transition:
       border-color 180ms ease,
       background 180ms ease,
       box-shadow 180ms ease,
       backdrop-filter 180ms ease,
       -webkit-backdrop-filter 180ms ease,
+      filter 180ms ease,
       transform 120ms ease;
   }
 
   .shell-mobile-nav-link.active .shell-mobile-nav-icon-frame {
-    border-color: rgba(120, 200, 255, 0.4);
+    border-color: rgba(117, 244, 255, 0.52);
     background:
-      linear-gradient(180deg, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0.1)),
-      rgba(130, 170, 224, 0.12);
+      linear-gradient(180deg, rgba(196, 255, 250, 0.34), rgba(126, 213, 255, 0.14)),
+      rgba(78, 164, 255, 0.18);
     box-shadow:
-      0 0 0 1px rgba(100, 185, 255, 0.12),
-      0 10px 22px rgba(31, 58, 112, 0.14),
-      inset 0 1px 0 rgba(255, 255, 255, 0.55),
-      inset 0 -1px 0 rgba(255, 255, 255, 0.15);
-    backdrop-filter: blur(10px) saturate(1.08);
-    -webkit-backdrop-filter: blur(10px) saturate(1.08);
+      0 0 0 1px rgba(120, 232, 255, 0.16),
+      0 12px 26px rgba(21, 87, 148, 0.24),
+      inset 0 1px 0 rgba(255, 255, 255, 0.62),
+      inset 0 -1px 0 rgba(130, 211, 255, 0.22);
+    filter: hue-rotate(-22deg) saturate(1.22);
   }
 
   .shell-mobile-nav-icon {
@@ -250,7 +255,9 @@
     height: 1.72rem;
     stroke: currentColor;
     stroke-width: 2.4;
-    fill: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    fill: none;
     filter: drop-shadow(0 8px 18px rgba(27, 45, 85, 0.35));
   }
 
@@ -368,8 +375,7 @@
     grid-template-columns: 1fr;
   }
 
-  .overview-location-dialog-header,
-  .overview-location-search-actions {
+  .overview-location-dialog-header {
     flex-direction: column;
     align-items: stretch;
   }
@@ -381,10 +387,6 @@
   .overview-location-dialog--picker {
     min-height: calc(100dvh - var(--bottom-nav-content-clearance) - 1.1rem);
     max-height: calc(100dvh - var(--bottom-nav-content-clearance) - 1.1rem);
-  }
-
-  .overview-location-picker-grid {
-    grid-template-columns: 1fr;
   }
 
   .overview-page-content-fresh {

--- a/ui/src/styles/rules.css
+++ b/ui/src/styles/rules.css
@@ -672,15 +672,15 @@
   justify-content: center;
   gap: 0.2rem;
   padding: 0.65rem 0.45rem;
-  border: 1px solid rgba(255, 255, 255, 0.38);
+  border: 1px solid rgba(255, 255, 255, 0.34);
   border-radius: 1.2rem;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0.10)),
-    rgba(130, 170, 224, 0.12);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.02)),
+    rgba(86, 112, 144, 0.84);
   box-shadow:
-    0 10px 22px rgba(31, 58, 112, 0.14),
-    inset 0 1px 0 rgba(255, 255, 255, 0.55),
-    inset 0 -1px 0 rgba(255, 255, 255, 0.15);
+    0 18px 34px rgba(31, 58, 112, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.05);
   -webkit-backdrop-filter: blur(10px) saturate(1.08);
   backdrop-filter: blur(10px) saturate(1.08);
   color: rgba(255, 255, 255, 0.95);
@@ -689,12 +689,17 @@
   text-align: center;
 }
 
+.rules-preset-tile {
+  gap: 0.7rem;
+  padding: 0.9rem 0.65rem;
+}
+
 .rules-tile:hover {
   transform: translateY(-2px);
   box-shadow:
-    0 14px 28px rgba(31, 58, 112, 0.22),
-    inset 0 1px 0 rgba(255, 255, 255, 0.6),
-    inset 0 -1px 0 rgba(255, 255, 255, 0.2);
+    0 20px 36px rgba(31, 58, 112, 0.34),
+    inset 0 1px 0 rgba(255, 255, 255, 0.22),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .rules-tile:active {
@@ -702,8 +707,40 @@
 }
 
 .rules-tile-icon {
-  font-size: 1.6rem;
+  display: grid;
+  place-items: center;
+  min-height: 1.8rem;
+  color: rgba(255, 255, 255, 0.96);
   line-height: 1;
+}
+
+.rules-tile-icon .rule-icon-glyph {
+  width: 1.55rem;
+  height: 1.55rem;
+}
+
+.rules-preset-tile .rules-tile-icon {
+  min-height: 2.8rem;
+}
+
+.rules-preset-tile .rules-tile-icon .rule-icon-glyph {
+  width: 2.25rem;
+  height: 2.25rem;
+}
+
+.rules-preset-tile .rules-tile-name {
+  font-size: clamp(1rem, 2.45vw, 1.14rem);
+  line-height: 1.14;
+  max-width: 10ch;
+}
+
+.rules-category-tile .rules-tile-icon {
+  min-height: 2.7rem;
+}
+
+.rules-category-tile .rules-tile-icon .rule-icon-glyph {
+  width: 2.15rem;
+  height: 2.15rem;
 }
 
 .rules-tile-name {
@@ -721,16 +758,16 @@
 }
 
 .rules-tile.is-enabled {
-  border-color: rgba(120, 200, 255, 0.55);
+  border-color: rgba(117, 244, 255, 0.56);
   background:
-    linear-gradient(180deg, rgba(100, 180, 255, 0.38), rgba(60, 140, 220, 0.18)),
-    rgba(80, 160, 240, 0.18);
+    linear-gradient(180deg, rgba(196, 255, 250, 0.16), rgba(126, 213, 255, 0.04)),
+    rgba(70, 118, 168, 0.88);
   box-shadow:
-    0 0 0 1px rgba(100, 185, 255, 0.3),
-    0 0 24px rgba(80, 160, 255, 0.18),
-    0 12px 28px rgba(31, 58, 112, 0.22),
-    inset 0 1px 0 rgba(180, 220, 255, 0.6),
-    inset 0 -1px 0 rgba(100, 180, 255, 0.2);
+    0 0 0 1px rgba(120, 232, 255, 0.18),
+    0 18px 36px rgba(21, 87, 148, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.22),
+    inset 0 -1px 0 rgba(130, 211, 255, 0.08);
+  filter: hue-rotate(-22deg) saturate(1.1);
 }
 
 .rules-tile.is-enabled .rules-tile-name {
@@ -824,8 +861,8 @@
 .rules-custom-rule-tile.is-muted {
   border-color: rgba(255, 255, 255, 0.22);
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0.06)),
-    rgba(110, 135, 175, 0.08);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.01)),
+    rgba(78, 99, 127, 0.68);
 }
 
 .rules-custom-select {
@@ -907,8 +944,15 @@
 }
 
 .rules-modal-icon {
-  font-size: 1.6rem;
+  display: grid;
+  place-items: center;
+  color: rgba(255, 255, 255, 0.96);
   line-height: 1;
+}
+
+.rules-modal-icon .rule-icon-glyph {
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .rules-modal-title {

--- a/ui/src/styles/subscription.css
+++ b/ui/src/styles/subscription.css
@@ -106,9 +106,15 @@
   flex-direction: column;
   gap: 0.55rem;
   padding: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.34);
   border-radius: 1.1rem;
-  background: rgba(30, 50, 90, 0.55);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.03)),
+    rgba(97, 124, 157, 0.72);
+  box-shadow:
+    0 16px 30px rgba(31, 58, 112, 0.26),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.06);
   backdrop-filter: blur(18px);
   -webkit-backdrop-filter: blur(18px);
   color: #fff;
@@ -119,8 +125,10 @@
 
 .sub-plan-tile:hover:not(:disabled) {
   transform: translateY(-2px);
-  border-color: rgba(120, 200, 255, 0.35);
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.25);
+  box-shadow:
+    0 18px 34px rgba(31, 58, 112, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.24),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .sub-plan-tile:disabled {
@@ -129,19 +137,21 @@
 }
 
 .sub-plan-tile.is-current {
-  border-color: rgba(120, 200, 255, 0.4);
-  box-shadow:
-    0 0 0 1px rgba(120, 200, 255, 0.12),
-    0 8px 24px rgba(0, 0, 0, 0.2);
+  border-color: var(--frost-tile-active-border);
+  background: var(--frost-tile-active-background);
+  box-shadow: var(--frost-tile-active-shadow);
+  filter: hue-rotate(-22deg) saturate(1.18);
 }
 
 .sub-plan-tile.is-pro {
-  background: rgba(50, 30, 90, 0.55);
-  border-color: rgba(168, 130, 255, 0.25);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.03)),
+    rgba(111, 88, 164, 0.74);
+  border-color: rgba(189, 160, 255, 0.34);
 }
 
 .sub-plan-tile.is-pro:hover:not(:disabled) {
-  border-color: rgba(168, 130, 255, 0.5);
+  border-color: rgba(202, 182, 255, 0.5);
 }
 
 /* plan tile internals */
@@ -153,7 +163,9 @@
 }
 
 .sub-plan-emoji {
-  font-size: 1.5rem;
+  display: grid;
+  place-items: center;
+  font-size: 1.72rem;
 }
 
 .sub-plan-price {

--- a/ui/src/styles/subscription.css
+++ b/ui/src/styles/subscription.css
@@ -162,7 +162,7 @@
   align-items: center;
 }
 
-.sub-plan-emoji {
+.sub-plan-icon {
   display: grid;
   place-items: center;
   font-size: 1.72rem;

--- a/ui/src/styles/tokens.css
+++ b/ui/src/styles/tokens.css
@@ -36,22 +36,38 @@
   --accent-soft-rgb: 144, 224, 239;
   --accent-deep-rgb: 3, 4, 94;
 
-  --panel-bg: var(--surface);
-  --panel-bg-muted: var(--surface-soft);
-  --panel-bg-hover: var(--surface-soft-hover);
+  --frost-surface-border: rgba(255, 255, 255, 0.36);
+  --frost-surface-bg:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.03)),
+    rgba(98, 126, 160, 0.6);
+  --frost-surface-bg-hover:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0.04)),
+    rgba(108, 138, 174, 0.68);
+  --frost-surface-shadow:
+    0 10px 24px rgba(31, 58, 112, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.34),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.1);
+  --frost-surface-shadow-hover:
+    0 16px 30px rgba(31, 58, 112, 0.24),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.12);
+
+  --panel-bg: var(--frost-surface-bg);
+  --panel-bg-muted: var(--frost-surface-bg);
+  --panel-bg-hover: var(--frost-surface-bg-hover);
   --panel-bg-popover: var(--surface-popover);
-  --panel-border: var(--surface-border);
+  --panel-border: var(--frost-surface-border);
   --panel-border-strong: var(--surface-border-strong);
-  --panel-shadow: 0 20px 35px var(--shadow-soft);
+  --panel-shadow: var(--frost-surface-shadow);
 
   --card-bg: var(--surface);
   --card-bg-muted: var(--surface-soft);
   --card-bg-hover: var(--surface-soft-hover);
-  --card-bg-elevated: linear-gradient(180deg, var(--surface) 0%, var(--surface-soft) 100%);
+  --card-bg-elevated: var(--frost-surface-bg);
   --card-bg-highlight: linear-gradient(180deg, var(--surface) 0%, rgba(var(--accent-bright-rgb), 0.14) 100%);
   --card-highlight-glow: radial-gradient(circle at top right, rgba(var(--accent-soft-rgb), 0.16) 0%, transparent 48%);
-  --card-shadow-soft: 0 10px 18px rgba(var(--accent-deep-rgb), 0.08);
-  --card-shadow-raised: 0 14px 28px rgba(var(--accent-deep-rgb), 0.12);
+  --card-shadow-soft: var(--frost-surface-shadow);
+  --card-shadow-raised: var(--frost-surface-shadow-hover);
 
   --control-bg: var(--field-bg);
   --control-bg-muted: var(--surface-soft);
@@ -120,20 +136,36 @@
   --accent-soft-rgb: 202, 240, 248;
   --accent-deep-rgb: 3, 4, 94;
 
-  --panel-bg: rgba(7, 18, 96, 0.9);
-  --panel-bg-muted: rgba(9, 26, 118, 0.9);
-  --panel-bg-hover: rgba(12, 33, 136, 0.94);
+  --frost-surface-border: rgba(202, 240, 248, 0.26);
+  --frost-surface-bg:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.02)),
+    rgba(10, 24, 76, 0.72);
+  --frost-surface-bg-hover:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.03)),
+    rgba(16, 34, 98, 0.8);
+  --frost-surface-shadow:
+    0 10px 24px rgba(0, 0, 0, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.14),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.06);
+  --frost-surface-shadow-hover:
+    0 16px 30px rgba(0, 0, 0, 0.32),
+    inset 0 1px 0 rgba(255, 255, 255, 0.16),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.08);
+
+  --panel-bg: var(--frost-surface-bg);
+  --panel-bg-muted: var(--frost-surface-bg);
+  --panel-bg-hover: var(--frost-surface-bg-hover);
   --panel-bg-popover: #07125e;
-  --panel-shadow: 0 20px 35px var(--shadow-strong);
+  --panel-shadow: var(--frost-surface-shadow);
 
   --card-bg: rgba(7, 18, 96, 0.9);
   --card-bg-muted: rgba(9, 26, 118, 0.88);
   --card-bg-hover: rgba(12, 33, 136, 0.94);
-  --card-bg-elevated: linear-gradient(180deg, rgba(7, 18, 96, 0.92) 0%, rgba(9, 26, 118, 0.88) 100%);
+  --card-bg-elevated: var(--frost-surface-bg);
   --card-bg-highlight: linear-gradient(180deg, rgba(7, 18, 96, 0.94) 0%, rgba(0, 180, 216, 0.14) 100%);
   --card-highlight-glow: radial-gradient(circle at top right, rgba(202, 240, 248, 0.12) 0%, transparent 48%);
-  --card-shadow-soft: 0 12px 24px rgba(0, 0, 0, 0.18);
-  --card-shadow-raised: 0 14px 28px rgba(0, 0, 0, 0.24);
+  --card-shadow-soft: var(--frost-surface-shadow);
+  --card-shadow-raised: var(--frost-surface-shadow-hover);
 
   --control-bg: var(--field-bg);
   --control-bg-muted: rgba(9, 26, 118, 0.9);

--- a/ui/src/styles/travel.css
+++ b/ui/src/styles/travel.css
@@ -31,6 +31,8 @@
 }
 
 .travel-empty-icon {
+  display: grid;
+  place-items: center;
   font-size: 3rem;
   line-height: 1;
 }
@@ -83,15 +85,15 @@
 .travel-tile {
   display: flex;
   flex-direction: column;
-  border: 1px solid rgba(255, 255, 255, 0.38);
+  border: 1px solid rgba(255, 255, 255, 0.34);
   border-radius: 1.2rem;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0.10)),
-    rgba(130, 170, 224, 0.12);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.03)),
+    rgba(97, 124, 157, 0.72);
   box-shadow:
-    0 10px 22px rgba(31, 58, 112, 0.14),
-    inset 0 1px 0 rgba(255, 255, 255, 0.55),
-    inset 0 -1px 0 rgba(255, 255, 255, 0.15);
+    0 16px 30px rgba(31, 58, 112, 0.26),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.06);
   backdrop-filter: blur(10px) saturate(1.08);
   -webkit-backdrop-filter: blur(10px) saturate(1.08);
   color: rgba(255, 255, 255, 0.95);
@@ -104,9 +106,9 @@
 .travel-tile:hover {
   transform: translateY(-2px);
   box-shadow:
-    0 14px 28px rgba(31, 58, 112, 0.22),
-    inset 0 1px 0 rgba(255, 255, 255, 0.6),
-    inset 0 -1px 0 rgba(255, 255, 255, 0.2);
+    0 18px 34px rgba(31, 58, 112, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.24),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .travel-tile:active {
@@ -114,16 +116,10 @@
 }
 
 .travel-tile.is-active {
-  border-color: rgba(120, 200, 255, 0.55);
-  background:
-    linear-gradient(180deg, rgba(100, 180, 255, 0.38), rgba(60, 140, 220, 0.18)),
-    rgba(80, 160, 240, 0.18);
-  box-shadow:
-    0 0 0 1px rgba(100, 185, 255, 0.3),
-    0 0 24px rgba(80, 160, 255, 0.18),
-    0 12px 28px rgba(31, 58, 112, 0.22),
-    inset 0 1px 0 rgba(180, 220, 255, 0.6),
-    inset 0 -1px 0 rgba(100, 180, 255, 0.2);
+  border-color: var(--frost-tile-active-border);
+  background: var(--frost-tile-active-background);
+  box-shadow: var(--frost-tile-active-shadow);
+  filter: hue-rotate(-22deg) saturate(1.18);
 }
 
 .travel-tile.is-past {
@@ -183,9 +179,18 @@
 
 .travel-tile-badge {
   margin-top: 0.3rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.32rem;
   font-size: 0.72rem;
   font-weight: 600;
   color: rgba(255, 255, 255, 0.75);
+}
+
+.travel-tile-badge-icon {
+  display: grid;
+  place-items: center;
+  font-size: 0.82rem;
 }
 
 /* ─── modal ─── */
@@ -242,6 +247,8 @@
 }
 
 .travel-modal-icon {
+  display: grid;
+  place-items: center;
   font-size: 1.6rem;
   line-height: 1;
 }
@@ -346,6 +353,9 @@
 }
 
 .travel-detail-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.32rem;
   font-size: 0.82rem;
   font-weight: 600;
   color: rgba(255, 255, 255, 0.75);


### PR DESCRIPTION
## Summary
- unify the recent UI polish work across overview, rules, location picker, plans, travel, and settings
- replace emoji/string icons with Lucide-based shared renderers and clean up the resulting code paths
- simplify the overview location picker to a direct-select modal and tighten recent glass/frost styling updates

## Validation
- cd ui && npm run lint
- cd ui && npm run build