### PR TITLE
fix: polish mobile overview and settings flows

### DIFF
--- a/ui/src/pages/OverviewPage.tsx
+++ b/ui/src/pages/OverviewPage.tsx
@@ -27,6 +27,56 @@ interface CustomOverviewView {
   hourlyForecast: WeatherCondition[]
 }
 
+const WEEKDAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'] as const
+
+function extractIsoCalendarDateParts(value?: string): { year: number; month: number; day: number } | null {
+  if (!value) {
+    return null
+  }
+
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (!match) {
+    return null
+  }
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  if ([year, month, day].some((part) => Number.isNaN(part))) {
+    return null
+  }
+
+  return { year, month, day }
+}
+
+function resolveCalendarDayKey(value?: string): string | null {
+  const parts = extractIsoCalendarDateParts(value)
+  if (parts) {
+    return `${parts.year}-${parts.month}-${parts.day}`
+  }
+
+  if (!value) {
+    return null
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
+}
+
+function extractHeadlineWeekday(item: WeatherCondition): string | null {
+  const headline = item.headline?.trim()
+  if (!headline) {
+    return null
+  }
+
+  const match = headline.match(/^(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday)\b/i)
+  return match ? `${match[1][0].toUpperCase()}${match[1].slice(1).toLowerCase()}` : null
+}
+
 function resolveDisplayTime(item: WeatherCondition): string | undefined {
   return item.onset ?? item.timestamp
 }
@@ -76,21 +126,31 @@ function buildWeatherVisualSource(
 
 function buildNextDailyItems(items: WeatherCondition[], count: number): WeatherCondition[] {
   const now = new Date()
-  const todayKey = `${now.getFullYear()}-${now.getMonth()}-${now.getDate()}`
+  const todayKey = `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`
+  const todayName = WEEKDAY_NAMES[now.getDay()]
+  const daytimeItems = new Map<string, WeatherCondition>()
+
+  for (const item of items) {
+    const weekdayName = extractHeadlineWeekday(item)
+    if (!weekdayName || weekdayName === todayName || daytimeItems.has(weekdayName)) {
+      continue
+    }
+
+    daytimeItems.set(weekdayName, item)
+    if (daytimeItems.size >= count) {
+      return Array.from(daytimeItems.values())
+    }
+  }
+
   const grouped = new Map<string, WeatherCondition>()
 
   for (const item of items) {
     const displayTime = resolveDisplayTime(item)
-    if (!displayTime) {
+    const dayKey = resolveCalendarDayKey(displayTime)
+    if (!dayKey) {
       continue
     }
 
-    const date = new Date(displayTime)
-    if (Number.isNaN(date.getTime())) {
-      continue
-    }
-
-    const dayKey = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`
     if (dayKey === todayKey || grouped.has(dayKey)) {
       continue
     }
@@ -99,6 +159,30 @@ function buildNextDailyItems(items: WeatherCondition[], count: number): WeatherC
   }
 
   return Array.from(grouped.values()).slice(0, count)
+}
+
+function formatDailyForecastLabel(item: WeatherCondition, fallbackIndex: number): string {
+  const headlineWeekday = extractHeadlineWeekday(item)
+  if (headlineWeekday) {
+    return headlineWeekday.slice(0, 3)
+  }
+
+  const displayTime = resolveDisplayTime(item)
+  const parts = extractIsoCalendarDateParts(displayTime)
+  if (parts) {
+    return new Intl.DateTimeFormat(undefined, { weekday: 'short', timeZone: 'UTC' }).format(
+      new Date(Date.UTC(parts.year, parts.month - 1, parts.day, 12)),
+    )
+  }
+
+  if (displayTime) {
+    const date = new Date(displayTime)
+    if (!Number.isNaN(date.getTime())) {
+      return date.toLocaleDateString(undefined, { weekday: 'short' })
+    }
+  }
+
+  return `Day ${fallbackIndex + 1}`
 }
 
 function areLocationsEquivalent(left: OverviewLocationSelection, right: OverviewLocationSelection): boolean {
@@ -404,16 +488,9 @@ export function OverviewPage() {
   const forecastItems = useMemo<MinimalForecastItem[]>(() => {
     const nextDailyItems = buildNextDailyItems(displayDailyForecast, 6)
     const dailyEntries = nextDailyItems.map((item, index) => {
-      const displayTime = resolveDisplayTime(item)
-      const dayDate = displayTime ? new Date(displayTime) : null
-      const dayLabel =
-        dayDate && !Number.isNaN(dayDate.getTime())
-          ? dayDate.toLocaleDateString(undefined, { weekday: 'short' })
-          : `Day ${index + 1}`
-
       return {
         id: `day-${item.id}`,
-        label: dayLabel,
+        label: formatDailyForecastLabel(item, index),
         temperatureLabel: formatTemperature(item.temperature, 'F'),
         precipitationLabel: formatPercentOrNA(item.precipitationProbability),
         icon: resolveWeatherIcon(item),

--- a/ui/src/pages/TravelPlansPage.tsx
+++ b/ui/src/pages/TravelPlansPage.tsx
@@ -217,22 +217,9 @@ export function TravelPlansPage() {
                     type="button"
                     onClick={() => openDetail(plan)}
                   >
-                    {plan.latitude != null && plan.longitude != null ? (
-                      <div className="travel-tile-map">
-                        <Suspense fallback={null}>
-                          <StaticLocationMap
-                            latitude={plan.latitude}
-                            longitude={plan.longitude}
-                            radiusKm={12}
-                            ariaLabel={`Map of ${plan.destination}`}
-                          />
-                        </Suspense>
-                      </div>
-                    ) : (
-                      <div className="travel-tile-map-placeholder">
-                        <span>{renderAppIcon(MapPinned)}</span>
-                      </div>
-                    )}
+                    <div className="travel-tile-map-placeholder" aria-hidden>
+                      <span>{renderAppIcon(MapPinned, 'travel-tile-map-icon', 2.15)}</span>
+                    </div>
                     <div className="travel-tile-body">
                       <p className="travel-tile-destination">{plan.destination ?? 'Destination'}</p>
                       <p className="travel-tile-name">{plan.name}</p>

--- a/ui/src/styles/account.css
+++ b/ui/src/styles/account.css
@@ -98,12 +98,14 @@
 
 .settings-input {
   width: 100%;
-  padding: 0.55rem 0.7rem;
+  min-height: 2.9rem;
+  padding: 0.7rem 0.85rem;
   border-radius: 0.6rem;
   border: 1px solid rgba(255, 255, 255, 0.15);
   background: rgba(255, 255, 255, 0.08);
   color: #fff;
-  font-size: 0.88rem;
+  font-size: 1rem;
+  line-height: 1.35;
   outline: none;
   transition: border-color 180ms ease, box-shadow 180ms ease;
   box-sizing: border-box;
@@ -131,13 +133,14 @@
 }
 
 .settings-input-toggle {
-  padding: 0 0.7rem;
+  min-height: 2.9rem;
+  padding: 0 0.85rem;
   border: 1px solid rgba(255, 255, 255, 0.15);
   border-left: none;
   border-radius: 0 0.6rem 0.6rem 0;
   background: rgba(255, 255, 255, 0.06);
   color: rgba(255, 255, 255, 0.55);
-  font-size: 0.72rem;
+  font-size: 0.78rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -155,19 +158,21 @@
 
 .settings-select {
   width: 100%;
-  padding: 0.55rem 0.7rem;
+  min-height: 2.9rem;
+  padding: 0.7rem 0.85rem;
   border-radius: 0.6rem;
   border: 1px solid rgba(255, 255, 255, 0.15);
   background: rgba(255, 255, 255, 0.08);
   color: #fff;
-  font-size: 0.88rem;
+  font-size: 1rem;
+  line-height: 1.35;
   outline: none;
   cursor: pointer;
   appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='rgba(255,255,255,0.5)' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10z'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right 0.65rem center;
-  padding-right: 2rem;
+  background-position: right 0.85rem center;
+  padding-right: 2.35rem;
   transition: border-color 180ms ease;
 }
 

--- a/ui/src/styles/dashboard.css
+++ b/ui/src/styles/dashboard.css
@@ -1022,6 +1022,7 @@
   display: grid;
   gap: 0.8rem;
   justify-content: start;
+  grid-template-columns: repeat(auto-fit, minmax(clamp(10.5rem, 40vw, 12rem), max-content));
 }
 
 .overview-official-alert-card h3 {
@@ -1272,7 +1273,46 @@ button.overview-official-alert-card:disabled {
 }
 
 .overview-recent-alerts-row .overview-official-alert-card {
-  width: min(100%, 28rem);
+  width: min(100%, clamp(10.5rem, 40vw, 12rem));
+  max-width: clamp(10.5rem, 40vw, 12rem);
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.55rem;
+  align-content: start;
+  padding: 0.9rem 0.88rem 0.95rem;
+}
+
+.overview-recent-alerts-row .overview-official-alert-icon {
+  width: 3rem;
+  height: 3rem;
+  justify-self: start;
+}
+
+.overview-recent-alerts-row .overview-official-alert-icon span {
+  font-size: 1.7rem;
+}
+
+.overview-recent-alerts-row .overview-official-alert-icon span .rule-icon-glyph,
+.overview-recent-alerts-row .overview-official-alert-icon span .app-icon-glyph {
+  width: 1.55rem;
+  height: 1.55rem;
+}
+
+.overview-recent-alerts-row .overview-official-alert-body {
+  gap: 0.22rem;
+}
+
+.overview-recent-alerts-row .overview-recent-alert-meta {
+  justify-content: space-between;
+  gap: 0.4rem;
+}
+
+.overview-recent-alerts-row .overview-official-alert-card h3 {
+  font-size: 1.12rem;
+  line-height: 1.1;
+}
+
+.overview-recent-alerts-row .overview-official-alert-area {
+  line-height: 1.25;
 }
 
 @keyframes overviewAlertDismiss {

--- a/ui/src/styles/travel.css
+++ b/ui/src/styles/travel.css
@@ -145,8 +145,32 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(255, 255, 255, 0.06);
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 50% 28%, rgba(134, 238, 255, 0.18), transparent 42%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02)),
+    rgba(71, 104, 143, 0.72);
   font-size: 1.6rem;
+}
+
+.travel-tile-map-placeholder::before,
+.travel-tile-map-placeholder::after {
+  content: '';
+  position: absolute;
+  inset: auto -12% 1.05rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.16), transparent);
+}
+
+.travel-tile-map-placeholder::after {
+  inset: 1.35rem -18% auto;
+}
+
+.travel-tile-map-icon {
+  font-size: 2rem;
+  color: rgba(255, 255, 255, 0.96);
+  filter: drop-shadow(0 8px 22px rgba(10, 18, 42, 0.28));
 }
 
 .travel-tile-body {


### PR DESCRIPTION
## Summary
- compact the overview custom alert cards so they no longer span the full page width
- normalize the overview 7 day strip against the day/night forecast feed and simplify travel tile previews to remove map console errors
- stop iPhone Safari focus-zoom on the Settings page by raising native form control font sizes to 16px

## Motivation
- clean up the remaining mobile regressions found during live browser inspection of the local app

## Testing
- `cd ui && npm run lint`
- `cd ui && npm run build`
- browser verification on the live local app via Playwright/MCP:
  - Settings inputs/selects compute to 16px and keep visual viewport scale at 1 on focus
  - Overview hourly toggle works and the forecast strip stays visible on deep scroll
  - Travel page loads with no console errors from the tile previews and still scrolls