### PR TITLE
feat: add settings logout action

### DIFF
--- a/ui/src/components/layout/AppShell.tsx
+++ b/ui/src/components/layout/AppShell.tsx
@@ -41,9 +41,13 @@ interface RouteTransitionState {
 const SWIPE_NAV_ITEMS = APP_PRIMARY_NAV_ITEMS
 
 const SWIPE_TARGET_BLOCKERS = [
+  'button',
+  'a',
   'input',
   'textarea',
   'select',
+  '[role="button"]',
+  '[role="link"]',
   '[role="dialog"]',
   '[aria-haspopup="dialog"]',
   '[contenteditable="true"]',

--- a/ui/src/pages/AccountPage.tsx
+++ b/ui/src/pages/AccountPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type FormEvent } from 'react'
-import { Monitor, Moon, Sun, type LucideIcon } from 'lucide-react'
+import { LogOut, Monitor, Moon, Sun, type LucideIcon } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useThemePreference, type ThemePreference } from '../theme'
 import {
@@ -22,7 +22,7 @@ const FALLBACK_OPTIONS = [
 ]
 
 export function AccountPage() {
-  const { me, initialDataLoading } = useSessionState()
+  const { me, initialDataLoading, logout } = useSessionState()
   const { notificationPreference } = useDataState()
   const { profileForm, setProfileForm, passwordForm, setPasswordForm } = useFormState()
   const { deletingAccount, savingProfile } = useAsyncState()
@@ -99,6 +99,11 @@ export function AccountPage() {
       setDeleteConfirmation('')
       navigate('/auth?accountDeleted=1', { replace: true })
     }
+  }
+
+  function onLogout() {
+    logout()
+    navigate('/auth', { replace: true })
   }
 
   function toggleChannel(channel: 'EMAIL' | 'SMS' | 'PUSH') {
@@ -318,6 +323,13 @@ export function AccountPage() {
                 Permanently removes your profile, alert rules, history, notification preferences, billing data,
                 email&nbsp;address, and phone&nbsp;number.
               </p>
+            </div>
+
+            <div className="settings-logout-row">
+              <button type="button" className="settings-logout-btn" onClick={onLogout}>
+                <LogOut size={18} strokeWidth={2.15} aria-hidden="true" />
+                <span>Log out</span>
+              </button>
             </div>
           </>
         )}

--- a/ui/src/styles/account.css
+++ b/ui/src/styles/account.css
@@ -505,3 +505,36 @@
   gap: 0.6rem;
   flex-wrap: wrap;
 }
+
+.settings-logout-row {
+  display: flex;
+  justify-content: center;
+  padding: 0.15rem 0 max(0.6rem, calc(var(--bottom-nav-content-clearance) * 0.08));
+}
+
+.settings-logout-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  width: min(100%, 20rem);
+  min-height: 3rem;
+  padding: 0.85rem 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  background: rgba(34, 53, 90, 0.56);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  cursor: pointer;
+  transition: transform 140ms ease, background 180ms ease, border-color 180ms ease;
+}
+
+.settings-logout-btn:hover {
+  transform: translateY(-1px);
+  background: rgba(44, 68, 112, 0.68);
+  border-color: rgba(255, 255, 255, 0.28);
+}


### PR DESCRIPTION
## Summary
- add a dedicated logout action at the bottom of the Settings page
- route logout through the existing session state and redirect to the auth landing page
- block shell swipe capture from hijacking in-page button and link taps

## Testing
- cd ui && npm run lint
- cd ui && npm run build
- browser verification on local mobile viewport: logged in, opened Settings, tapped Log out, confirmed redirect to /auth and token cleared